### PR TITLE
Fix agent selection, session creation flow, and session sorting

### DIFF
--- a/src/components/chat/ChatTab.tsx
+++ b/src/components/chat/ChatTab.tsx
@@ -18,7 +18,7 @@ import * as DocumentPicker from 'expo-document-picker';
 import * as ImagePicker from 'expo-image-picker';
 import * as FileSystem from 'expo-file-system/legacy';
 import { useStore } from '../../store';
-import { ChatMessage, ChatMessagePart, MessageAttachment, Server, Session } from '../../types';
+import { Agent, ChatMessage, ChatMessagePart, MessageAttachment, Server, Session } from '../../types';
 import { OpenCodeService, Message as ApiMessage, ToolMetadata } from '../../services/opencode';
 import { useThemeColors } from '../../hooks/useThemeColors';
 import MarkdownRenderer from './MarkdownRenderer';
@@ -117,14 +117,33 @@ export default function ChatTab({ session, server }: ChatTabProps) {
   const flatListRef = useRef<FlatList>(null);
   const [service] = useState(() => new OpenCodeService(server));
 
-  const [selectedAgent, setSelectedAgent] = useState<string>('coder');
+  const [selectedAgent, setSelectedAgent] = useState<string>('build');
   const [showAgentPicker, setShowAgentPicker] = useState(false);
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [agentsLoading, setAgentsLoading] = useState(true);
 
-  const AGENTS = [
-    { id: 'coder', label: 'Coder', description: 'Default coding agent' },
-    { id: 'task', label: 'Task', description: 'Task-oriented agent' },
-    { id: 'explore', label: 'Explore', description: 'Codebase exploration' },
-  ];
+  useEffect(() => {
+    const loadAgents = async () => {
+      try {
+        setAgentsLoading(true);
+        const fetchedAgents = await service.getAgents();
+        // Show only non-hidden primary agents in the picker
+        const primaryAgents = fetchedAgents.filter(
+          (a) => a.mode === 'primary' && !a.hidden
+        );
+        setAgents(primaryAgents);
+        // Default to first primary agent if current selection isn't in the list
+        if (primaryAgents.length > 0 && !primaryAgents.find((a) => a.name === selectedAgent)) {
+          setSelectedAgent(primaryAgents[0].name);
+        }
+      } catch (error) {
+        console.error('Error loading agents:', error);
+      } finally {
+        setAgentsLoading(false);
+      }
+    };
+    loadAgents();
+  }, [service]);
 
   const sessionMessages = messages[session.id] || [];
   const canLoadMore = hasMoreMessages[session.id] ?? true;
@@ -302,7 +321,8 @@ export default function ChatTab({ session, server }: ChatTabProps) {
         (chunk) => {
           fullResponse += chunk;
           setStreamingText(fullResponse);
-        }
+        },
+        selectedAgent
       );
 
       const assistantMessage: ChatMessage = {
@@ -529,14 +549,20 @@ keyExtractor={(item: MessageAttachment) => item.id}
         {/* Agent selector row */}
         <View className="flex-row items-center px-3 pt-2 pb-1">
           <Text className="text-text-subtle text-xs mr-2">Agent:</Text>
-          <TouchableOpacity
-            onPress={() => setShowAgentPicker(true)}
-            className="flex-row items-center bg-surface-elevated px-2.5 py-1 rounded-full border border-border"
-            testID="agent-selector"
-          >
-            <Text className="text-text text-xs font-medium">{AGENTS.find(a => a.id === selectedAgent)?.label ?? selectedAgent}</Text>
-            <Text className="text-text-muted text-[10px] ml-1">▼</Text>
-          </TouchableOpacity>
+          {agentsLoading ? (
+            <ActivityIndicator size="small" color={colors.textMuted} />
+          ) : agents.length > 0 ? (
+            <TouchableOpacity
+              onPress={() => setShowAgentPicker(true)}
+              className="flex-row items-center bg-surface-elevated px-2.5 py-1 rounded-full border border-border"
+              testID="agent-selector"
+            >
+              <Text className="text-text text-xs font-medium">{agents.find(a => a.name === selectedAgent)?.name ?? selectedAgent}</Text>
+              <Text className="text-text-muted text-[10px] ml-1">▼</Text>
+            </TouchableOpacity>
+          ) : (
+            <Text className="text-text-subtle text-xs">No agents available</Text>
+          )}
         </View>
 
         {/* Input row */}
@@ -597,22 +623,24 @@ keyExtractor={(item: MessageAttachment) => item.id}
         >
           <View className="bg-surface rounded-t-2xl p-4 pb-8">
             <Text className="text-text font-semibold text-base mb-3">Select Agent</Text>
-            {AGENTS.map((agent) => (
+            {agents.map((agent) => (
               <TouchableOpacity
-                key={agent.id}
-                className={`flex-row items-center p-3 rounded-lg mb-1 ${selectedAgent === agent.id ? 'bg-primary/10 border border-primary' : 'border border-transparent'}`}
+                key={agent.name}
+                className={`flex-row items-center p-3 rounded-lg mb-1 ${selectedAgent === agent.name ? 'bg-primary/10 border border-primary' : 'border border-transparent'}`}
                 onPress={() => {
-                  setSelectedAgent(agent.id);
+                  setSelectedAgent(agent.name);
                   setShowAgentPicker(false);
                 }}
               >
                 <View className="flex-1">
-                  <Text className={`text-sm font-medium ${selectedAgent === agent.id ? 'text-primary' : 'text-text'}`}>
-                    {agent.label}
+                  <Text className={`text-sm font-medium ${selectedAgent === agent.name ? 'text-primary' : 'text-text'}`}>
+                    {agent.name}
                   </Text>
-                  <Text className="text-text-subtle text-xs">{agent.description}</Text>
+                  {agent.description && (
+                    <Text className="text-text-subtle text-xs">{agent.description}</Text>
+                  )}
                 </View>
-                {selectedAgent === agent.id && (
+                {selectedAgent === agent.name && (
                   <Text className="text-primary text-sm">✓</Text>
                 )}
               </TouchableOpacity>

--- a/src/screens/sessions/NewSessionScreen.tsx
+++ b/src/screens/sessions/NewSessionScreen.tsx
@@ -53,7 +53,7 @@ export default function NewSessionScreen() {
         };
         
         await addSession(session);
-        navigation.goBack();
+        navigation.replace('SessionDetail', { session, server });
       } else {
         Alert.alert('Error', 'Failed to create session on server');
       }

--- a/src/screens/sessions/SessionsScreen.tsx
+++ b/src/screens/sessions/SessionsScreen.tsx
@@ -142,7 +142,7 @@ export default function SessionsScreen() {
         </View>
       ) : (
         <FlatList
-          data={[...new Map(sessions.map(s => [s.id, s])).values()].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())}
+          data={[...new Map(sessions.map(s => [s.id, s])).values()].sort((a, b) => new Date(b.updatedAt ?? b.createdAt).getTime() - new Date(a.updatedAt ?? a.createdAt).getTime())}
           renderItem={renderSession}
           keyExtractor={(item: Session) => item.id}
           contentContainerClassName="p-4"

--- a/src/services/opencode.ts
+++ b/src/services/opencode.ts
@@ -142,10 +142,10 @@ export class OpenCodeService {
         serverId: '', // Will be set by the caller
         title: apiSession.title,
         createdAt: apiSession.time?.created
-          ? new Date(apiSession.time.created * 1000).toISOString()
+          ? new Date(apiSession.time.created).toISOString()
           : new Date().toISOString(),
         updatedAt: apiSession.time?.updated
-          ? new Date(apiSession.time.updated * 1000).toISOString()
+          ? new Date(apiSession.time.updated).toISOString()
           : undefined,
       }));
     } catch (error) {

--- a/src/services/opencode.ts
+++ b/src/services/opencode.ts
@@ -1,4 +1,4 @@
-import { Server, Session, GitFile } from '../types';
+import { Server, Session, GitFile, Agent } from '../types';
 import EventSource from 'react-native-sse';
 import base64 from 'base-64';
 
@@ -154,6 +154,20 @@ export class OpenCodeService {
     }
   }
 
+  async getAgents(): Promise<Agent[]> {
+    try {
+      const response = await fetch(`${this.baseUrl}/agent`, {
+        headers: this.getHeaders(),
+      });
+      if (!response.ok) throw new Error('Failed to fetch agents');
+      const data: Agent[] = await response.json();
+      return data;
+    } catch (error) {
+      console.error('Error fetching agents:', error);
+      return [];
+    }
+  }
+
   async createSession(title: string): Promise<Session | null> {
     try {
       const response = await fetch(`${this.baseUrl}/session`, {
@@ -229,7 +243,8 @@ export class OpenCodeService {
     sessionId: string,
     message: string,
     attachments?: Array<{ type: string; content: string; name: string; mimeType?: string }>,
-    onChunk?: (text: string) => void
+    onChunk?: (text: string) => void,
+    agentId?: string
   ): Promise<string> {
     try {
       // Prepare message parts
@@ -260,10 +275,15 @@ export class OpenCodeService {
       }
 
       // Send message to OpenCode server
+      const body: Record<string, any> = { parts };
+      if (agentId) {
+        body.agentID = agentId;
+      }
+
       const response = await fetch(`${this.baseUrl}/session/${sessionId}/message`, {
         method: 'POST',
         headers: this.getHeaders(),
-        body: JSON.stringify({ parts }),
+        body: JSON.stringify(body),
       });
 
       if (!response.ok) throw new Error('Failed to send message');
@@ -293,7 +313,8 @@ export class OpenCodeService {
     sessionId: string,
     message: string,
     attachments?: Array<{ type: string; content: string; name: string; mimeType?: string }>,
-    onChunk?: (text: string) => void
+    onChunk?: (text: string) => void,
+    agentId?: string
   ): Promise<string> {
     try {
       // Prepare message parts
@@ -334,10 +355,15 @@ export class OpenCodeService {
 
       return new Promise((resolve, reject) => {
         // First, send the message asynchronously
+        const asyncBody: Record<string, any> = { parts };
+        if (agentId) {
+          asyncBody.agentID = agentId;
+        }
+
         fetch(`${this.baseUrl}/session/${sessionId}/prompt_async`, {
           method: 'POST',
           headers: this.getHeaders(),
-          body: JSON.stringify({ parts }),
+          body: JSON.stringify(asyncBody),
         }).catch(reject);
 
         eventSource.addEventListener('message', (event: any) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -102,6 +102,14 @@ export interface FileAnnotation {
   }>;
 }
 
+export interface Agent {
+  name: string;
+  description?: string;
+  mode: 'primary' | 'subagent' | 'all';
+  hidden?: boolean;
+  native?: boolean;
+}
+
 export interface TerminalState {
   history: string[];
   currentInput: string;


### PR DESCRIPTION
## Summary

Fixes three open issues related to session management and agent selection:

- **#6 — Agent selection is wrong**: Replace hardcoded agent list ("Coder", "Task", "Explore") with dynamic fetch from the OpenCode server via `GET /agent`. Filters to non-hidden primary agents and passes the selected `agentID` in message requests so agent selection actually takes effect.
- **#8 — Session creation flow**: After creating a session, navigate directly into the new session detail view instead of going back to the sessions list.
- **#7 — Session sorting**: Sort sessions by `updatedAt` (with `createdAt` fallback) so recently active sessions appear at the top. Also fixes a timestamp conversion bug where millisecond-epoch values from the API were incorrectly multiplied by 1000.

## Changes

### Agent Selection (`#6`)
- `src/types/index.ts` — Add `Agent` interface
- `src/services/opencode.ts` — Add `getAgents()` method; update `sendMessage()` and `streamMessage()` to accept and forward `agentID`
- `src/components/chat/ChatTab.tsx` — Fetch agents dynamically on mount, filter to primary non-hidden agents, pass selected agent to API, add loading/empty states

### Session Creation Navigation (`#8`)
- `src/screens/sessions/NewSessionScreen.tsx` — Replace `navigation.goBack()` with `navigation.replace('SessionDetail', { session, server })`

### Session Sorting (`#7`)
- `src/screens/sessions/SessionsScreen.tsx` — Sort by `updatedAt` instead of `createdAt`
- `src/services/opencode.ts` — Fix timestamp conversion (API returns ms, not seconds)

Closes #6, #7, #8