### PR TITLE
Add GitHub Actions workflow to build APK on pull requests

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,122 @@
+name: PR Build APK
+
+on:
+  pull_request:
+    branches: [main, master]
+    paths-ignore:
+      - "**.md"
+      - "LICENSE"
+      - "docs/**"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+
+jobs:
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run TypeScript check
+        run: yarn tsc
+
+  build-apk:
+    name: Build APK
+    needs: typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "yarn"
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Setup Expo & EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          expo-version: latest
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Cache EAS local builds
+        uses: actions/cache@v3
+        with:
+          path: ~/.eas-build-local
+          key: ${{ runner.os }}-eas-build-local-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-eas-build-local-
+
+      - name: Generate ephemeral signing keystore
+        run: |
+          keytool -genkeypair -v \
+            -keystore android-keystore.jks \
+            -alias release \
+            -keyalg RSA -keysize 2048 -validity 10000 \
+            -storepass android -keypass android \
+            -dname "CN=PR Build, O=CI, C=US"
+          cat > credentials.json << 'CREDS'
+          {
+            "android": {
+              "keystore": {
+                "keystorePath": "android-keystore.jks",
+                "keystorePassword": "android",
+                "keyAlias": "release",
+                "keyPassword": "android"
+              }
+            }
+          }
+          CREDS
+
+      - name: Build APK
+        run: |
+          eas build --platform android --profile preview-local --local \
+            --output ./app-pr-${{ github.event.pull_request.number }}.apk \
+            --non-interactive
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        id: upload-apk
+        with:
+          name: pr-apk-${{ github.event.pull_request.number }}
+          path: ./app-pr-${{ github.event.pull_request.number }}.apk
+          retention-days: 14
+
+      - name: Comment on PR with APK link
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: apk-build
+          message: |
+            **APK Build Successful**
+
+            Download the APK from [this workflow run's artifacts](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+
+            - **Artifact:** `pr-apk-${{ github.event.pull_request.number }}`
+            - **Commit:** `${{ github.event.pull_request.head.sha }}`
+            - **Expires:** 14 days


### PR DESCRIPTION
## Summary

- Adds a new CI workflow (`.github/workflows/pr-build.yml`) that builds an Android APK on every pull request targeting `main`/`master`
- Runs a TypeScript type check before building to catch errors early
- Uses EAS local build with the `preview-local` profile and an ephemeral signing keystore
- Uploads the APK as a GitHub Actions artifact (14-day retention) and posts a sticky comment on the PR with a download link
- Skips on docs-only changes (markdown, LICENSE, docs/)

## Workflow Overview

```
PR opened/updated → typecheck (yarn tsc) → build APK (eas build --local) → upload artifact + comment on PR
```