### PR TITLE
Add project handling between servers and sessions

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -8,6 +8,8 @@ import { withUniwind } from 'uniwind';
 
 const StyledView = withUniwind(View);
 import ServersScreen from './src/screens/servers/ServersScreen';
+import ProjectsScreen from './src/screens/projects/ProjectsScreen';
+import SelectDirectoryScreen from './src/screens/projects/SelectDirectoryScreen';
 import SessionsScreen from './src/screens/sessions/SessionsScreen';
 import SessionDetailScreen from './src/screens/session-detail/SessionDetailScreen';
 import AddEditServerScreen from './src/screens/servers/AddEditServerScreen';
@@ -34,6 +36,8 @@ export default function App() {
               }}
             >
               <Stack.Screen name="Servers" component={ServersScreen} />
+              <Stack.Screen name="Projects" component={ProjectsScreen} />
+              <Stack.Screen name="SelectDirectory" component={SelectDirectoryScreen} />
               <Stack.Screen name="Sessions" component={SessionsScreen} />
               <Stack.Screen name="SessionDetail" component={SessionDetailScreen} />
               <Stack.Screen name="AddEditServer" component={AddEditServerScreen} />

--- a/src/__tests__/opencode-api.test.ts
+++ b/src/__tests__/opencode-api.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Integration tests for OpenCode API endpoints used by the project/directory features.
+ *
+ * These tests run against a live OpenCode server.
+ * Usage: npx tsx src/__tests__/opencode-api.test.ts [base-url]
+ *
+ * Default base URL: http://localhost:4096
+ */
+
+const BASE_URL = process.argv[2] || 'http://localhost:4096';
+
+interface TestResult {
+  name: string;
+  passed: boolean;
+  error?: string;
+}
+
+const results: TestResult[] = [];
+
+async function test(name: string, fn: () => Promise<void>) {
+  try {
+    await fn();
+    results.push({ name, passed: true });
+    console.log(`  ✓ ${name}`);
+  } catch (err: any) {
+    results.push({ name, passed: false, error: err.message });
+    console.log(`  ✗ ${name}`);
+    console.log(`    ${err.message}`);
+  }
+}
+
+function assert(condition: boolean, message: string) {
+  if (!condition) throw new Error(message);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+async function run() {
+  console.log(`\nRunning OpenCode API integration tests against ${BASE_URL}\n`);
+
+  // --- GET /path -----------------------------------------------------------
+
+  console.log('GET /path');
+
+  let homePath = '';
+  let cwdPath = '';
+
+  await test('returns home and directory', async () => {
+    const res = await fetch(`${BASE_URL}/path`);
+    assert(res.ok, `Expected 200, got ${res.status}`);
+    const data = await res.json();
+    assert(typeof data.home === 'string' && data.home.length > 0, 'home should be a non-empty string');
+    assert(typeof data.directory === 'string' && data.directory.length > 0, 'directory should be a non-empty string');
+    homePath = data.home;
+    cwdPath = data.directory;
+  });
+
+  // --- GET /project --------------------------------------------------------
+
+  console.log('\nGET /project');
+
+  await test('returns an array of projects', async () => {
+    const res = await fetch(`${BASE_URL}/project`);
+    assert(res.ok, `Expected 200, got ${res.status}`);
+    const data = await res.json();
+    assert(Array.isArray(data), 'response should be an array');
+    if (data.length > 0) {
+      const p = data[0];
+      assert(typeof p.id === 'string', 'project should have string id');
+      assert(typeof p.worktree === 'string', 'project should have string worktree');
+      assert(typeof p.time === 'object', 'project should have time object');
+      assert(typeof p.time.created === 'number', 'project.time.created should be a number');
+    }
+  });
+
+  // --- GET /file -----------------------------------------------------------
+
+  console.log('\nGET /file (directory listing)');
+
+  await test('returns 422 without path param', async () => {
+    const res = await fetch(`${BASE_URL}/file?directory=${encodeURIComponent(cwdPath)}`);
+    // The API requires both directory and path
+    assert(!res.ok, `Expected error status, got ${res.status}`);
+  });
+
+  await test('lists files in cwd with path=.', async () => {
+    const res = await fetch(
+      `${BASE_URL}/file?directory=${encodeURIComponent(cwdPath)}&path=.`,
+    );
+    assert(res.ok, `Expected 200, got ${res.status}`);
+    const data = await res.json();
+    assert(Array.isArray(data), 'response should be an array');
+    assert(data.length > 0, 'cwd should have at least one entry');
+    const entry = data[0];
+    assert(typeof entry.name === 'string', 'entry should have string name');
+    assert(typeof entry.absolute === 'string', 'entry should have string absolute');
+    assert(['file', 'directory'].includes(entry.type), `entry.type should be file or directory, got ${entry.type}`);
+    assert(typeof entry.ignored === 'boolean', 'entry.ignored should be boolean');
+  });
+
+  await test('contains directories when listing cwd', async () => {
+    const res = await fetch(
+      `${BASE_URL}/file?directory=${encodeURIComponent(cwdPath)}&path=.`,
+    );
+    const data = await res.json();
+    const dirs = data.filter((e: any) => e.type === 'directory');
+    assert(dirs.length > 0, 'cwd should contain at least one directory (e.g. src, node_modules)');
+  });
+
+  await test('lists home directory contents', async () => {
+    const res = await fetch(
+      `${BASE_URL}/file?directory=${encodeURIComponent(homePath)}&path=.`,
+    );
+    assert(res.ok, `Expected 200, got ${res.status}`);
+    const data = await res.json();
+    assert(Array.isArray(data), 'response should be an array');
+    assert(data.length > 0, 'home directory should have entries');
+  });
+
+  await test('absolute path works as directory param', async () => {
+    const res = await fetch(
+      `${BASE_URL}/file?directory=${encodeURIComponent('/')}&path=.`,
+    );
+    assert(res.ok, `Expected 200, got ${res.status}`);
+    const data = await res.json();
+    assert(Array.isArray(data), 'response should be an array');
+    assert(data.length > 0, 'root directory should have entries');
+  });
+
+  await test('directory entries have correct absolute paths', async () => {
+    const res = await fetch(
+      `${BASE_URL}/file?directory=${encodeURIComponent(homePath)}&path=.`,
+    );
+    const data = await res.json();
+    const dirs = data.filter((e: any) => e.type === 'directory');
+    if (dirs.length > 0) {
+      const dir = dirs[0];
+      assert(
+        dir.absolute.startsWith(homePath),
+        `absolute path "${dir.absolute}" should start with home "${homePath}"`,
+      );
+    }
+  });
+
+  // --- GET /find/file ------------------------------------------------------
+
+  console.log('\nGET /find/file (directory search)');
+
+  await test('finds directories by query', async () => {
+    const res = await fetch(
+      `${BASE_URL}/find/file?directory=${encodeURIComponent(cwdPath)}&query=src&type=directory&limit=10`,
+    );
+    assert(res.ok, `Expected 200, got ${res.status}`);
+    const data = await res.json();
+    assert(Array.isArray(data), 'response should be an array');
+    // src directory should exist in this project
+    assert(data.length > 0, 'should find at least one result for "src"');
+  });
+
+  await test('returns strings (relative paths), not objects', async () => {
+    const res = await fetch(
+      `${BASE_URL}/find/file?directory=${encodeURIComponent(cwdPath)}&query=src&type=directory&limit=10`,
+    );
+    const data = await res.json();
+    if (data.length > 0) {
+      assert(typeof data[0] === 'string', `expected string results, got ${typeof data[0]}: ${JSON.stringify(data[0])}`);
+    }
+  });
+
+  await test('respects limit parameter', async () => {
+    const res = await fetch(
+      `${BASE_URL}/find/file?directory=${encodeURIComponent(cwdPath)}&query=s&type=directory&limit=3`,
+    );
+    const data = await res.json();
+    assert(data.length <= 3, `expected at most 3 results, got ${data.length}`);
+  });
+
+  await test('returns empty array for non-matching query', async () => {
+    const res = await fetch(
+      `${BASE_URL}/find/file?directory=${encodeURIComponent(cwdPath)}&query=zzz_nonexistent_xyz&type=directory&limit=10`,
+    );
+    assert(res.ok, `Expected 200, got ${res.status}`);
+    const data = await res.json();
+    assert(Array.isArray(data), 'response should be an array');
+    assert(data.length === 0, `expected 0 results, got ${data.length}`);
+  });
+
+  // --- GET /session (with directory filter) --------------------------------
+
+  console.log('\nGET /session (directory filtering)');
+
+  await test('returns sessions array', async () => {
+    const res = await fetch(`${BASE_URL}/session`);
+    assert(res.ok, `Expected 200, got ${res.status}`);
+    const data = await res.json();
+    assert(Array.isArray(data), 'response should be an array');
+  });
+
+  await test('sessions have projectID and directory fields', async () => {
+    const res = await fetch(`${BASE_URL}/session`);
+    const data = await res.json();
+    if (data.length > 0) {
+      const s = data[0];
+      assert('projectID' in s, 'session should have projectID field');
+      assert('directory' in s, 'session should have directory field');
+      assert('parentID' in s || !s.parentID, 'session may have parentID field');
+    }
+  });
+
+  await test('filters sessions by directory param', async () => {
+    const res = await fetch(
+      `${BASE_URL}/session?directory=${encodeURIComponent(cwdPath)}`,
+    );
+    assert(res.ok, `Expected 200, got ${res.status}`);
+    const data = await res.json();
+    assert(Array.isArray(data), 'response should be an array');
+    // All returned sessions should belong to the specified directory
+    for (const s of data) {
+      assert(
+        s.directory === cwdPath,
+        `session directory "${s.directory}" should match filter "${cwdPath}"`,
+      );
+    }
+  });
+
+  // --- Summary -------------------------------------------------------------
+
+  console.log('\n' + '='.repeat(60));
+  const passed = results.filter((r) => r.passed).length;
+  const failed = results.filter((r) => !r.passed).length;
+  console.log(`Results: ${passed} passed, ${failed} failed, ${results.length} total`);
+
+  if (failed > 0) {
+    console.log('\nFailed tests:');
+    for (const r of results.filter((r) => !r.passed)) {
+      console.log(`  ✗ ${r.name}: ${r.error}`);
+    }
+    process.exit(1);
+  } else {
+    console.log('\nAll tests passed!');
+    process.exit(0);
+  }
+}
+
+run().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -1,11 +1,13 @@
 import { NavigatorScreenParams } from '@react-navigation/native';
-import { Server, Session, GitFile } from '../types';
+import { Server, Session, GitFile, Project } from '../types';
 
 export type RootStackParamList = {
   Servers: undefined;
   AddEditServer: { server?: Server };
-  Sessions: { server: Server };
-  NewSession: { server: Server };
+  Projects: { server: Server };
+  SelectDirectory: { server: Server };
+  Sessions: { server: Server; project?: Project };
+  NewSession: { server: Server; project?: Project };
   SessionDetail: { session: Session; server: Server };
   GitDiffViewer: { file: GitFile; session: Session; server: Server };
   ConnectionLogs: { serverId: string; serverName: string };

--- a/src/screens/projects/ProjectsScreen.tsx
+++ b/src/screens/projects/ProjectsScreen.tsx
@@ -173,8 +173,8 @@ export default function ProjectsScreen() {
         >
           <Text className="text-base text-primary">← Back</Text>
         </TouchableOpacity>
-        <View className="items-center">
-          <Text className="text-xl font-bold text-text">{server.name}</Text>
+        <View className="flex-1 items-center mx-3">
+          <Text className="text-xl font-bold text-text" numberOfLines={1}>{server.name}</Text>
           <Text className="text-xs text-text-muted">Projects</Text>
         </View>
         <TouchableOpacity
@@ -182,7 +182,7 @@ export default function ProjectsScreen() {
           onPress={() => navigation.navigate('SelectDirectory', { server })}
           testID="open-folder-btn"
         >
-          <Text className="text-white font-semibold">+ Open</Text>
+          <Text className="text-white font-semibold">Open</Text>
         </TouchableOpacity>
       </View>
 

--- a/src/screens/projects/ProjectsScreen.tsx
+++ b/src/screens/projects/ProjectsScreen.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+// Placeholder — full implementation in next commit
+export default function ProjectsScreen() {
+  return (
+    <SafeAreaView style={{ flex: 1 }}>
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <Text>Projects</Text>
+      </View>
+    </SafeAreaView>
+  );
+}

--- a/src/screens/projects/ProjectsScreen.tsx
+++ b/src/screens/projects/ProjectsScreen.tsx
@@ -1,14 +1,212 @@
-import React from 'react';
-import { View, Text } from 'react-native';
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  Alert,
+  ActivityIndicator,
+} from 'react-native';
+import { useNavigation, useRoute, RouteProp, useFocusEffect } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { withUniwind } from 'uniwind';
+import { useStore } from '../../store';
+import { Project } from '../../types';
+import { RootStackParamList } from '../../navigation/types';
+import { OpenCodeService } from '../../services/opencode';
+import { useThemeColors } from '../../hooks/useThemeColors';
 
-// Placeholder — full implementation in next commit
+const StyledSafeAreaView = withUniwind(SafeAreaView);
+
+type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'Projects'>;
+type ProjectsRouteProp = RouteProp<RootStackParamList, 'Projects'>;
+
+// Pseudo-project sentinel for "All Sessions"
+const ALL_SESSIONS_ITEM = { __allSessions: true } as const;
+type ListItem = Project | typeof ALL_SESSIONS_ITEM;
+
+function isAllSessions(item: ListItem): item is typeof ALL_SESSIONS_ITEM {
+  return '__allSessions' in item;
+}
+
+function getDirectoryBasename(worktree: string): string {
+  const parts = worktree.replace(/\/+$/, '').split('/');
+  return parts[parts.length - 1] || worktree;
+}
+
 export default function ProjectsScreen() {
+  const navigation = useNavigation<NavigationProp>();
+  const route = useRoute<ProjectsRouteProp>();
+  const colors = useThemeColors();
+  const { server } = route.params;
+
+  const { projects, loadProjects, openProject, closeProject, enrichProjects } = useStore();
+  const [loading, setLoading] = useState(false);
+  const [service] = useState(() => new OpenCodeService(server));
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    try {
+      // Load locally-tracked projects
+      await loadProjects(server.id);
+
+      // Fetch API projects and enrich + auto-open
+      const apiProjects = await service.getProjects();
+      const apiWithServerId = apiProjects.map(p => ({ ...p, serverId: server.id }));
+
+      // Auto-open any API projects not already in the local list
+      const currentProjects = useStore.getState().projects;
+      for (const ap of apiWithServerId) {
+        const exists = currentProjects.find(p => p.worktree === ap.worktree && p.serverId === server.id);
+        if (!exists) {
+          await openProject(ap);
+        }
+      }
+
+      // Enrich local projects with API metadata (id, vcs, timestamps)
+      await enrichProjects(server.id, apiWithServerId);
+    } catch (error) {
+      console.error('Error loading projects:', error);
+      Alert.alert('Error', 'Failed to load projects from server');
+    } finally {
+      setLoading(false);
+    }
+  }, [server.id]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  // Refresh when navigating back from SelectDirectory
+  useFocusEffect(
+    useCallback(() => {
+      loadData();
+    }, [loadData])
+  );
+
+  const serverProjects = projects.filter(p => p.serverId === server.id);
+
+  const handleSelectProject = (project: Project) => {
+    navigation.navigate('Sessions', { server, project });
+  };
+
+  const handleAllSessions = () => {
+    navigation.navigate('Sessions', { server });
+  };
+
+  const handleCloseProject = (project: Project) => {
+    Alert.alert(
+      'Close Project',
+      `Remove "${getDirectoryBasename(project.worktree)}" from your project list? This does not delete any data on the server.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Close',
+          style: 'destructive',
+          onPress: async () => {
+            await closeProject(server.id, project.worktree);
+          },
+        },
+      ]
+    );
+  };
+
+  const listData: ListItem[] = [ALL_SESSIONS_ITEM, ...serverProjects];
+
+  const renderItem = ({ item }: { item: ListItem }): React.ReactElement => {
+    if (isAllSessions(item)) {
+      return (
+        <TouchableOpacity
+          className="bg-surface rounded-xl p-4 mb-3 shadow-sm flex-row items-center"
+          onPress={handleAllSessions}
+          testID="all-sessions-item"
+        >
+          <View className="w-10 h-10 rounded-lg bg-primary/15 items-center justify-center mr-3">
+            <Text className="text-primary text-lg font-bold">*</Text>
+          </View>
+          <View className="flex-1">
+            <Text className="text-lg font-semibold text-text">All Sessions</Text>
+            <Text className="text-xs text-text-muted mt-1">Browse sessions across all projects</Text>
+          </View>
+        </TouchableOpacity>
+      );
+    }
+
+    const basename = getDirectoryBasename(item.worktree);
+
+    return (
+      <TouchableOpacity
+        className="bg-surface rounded-xl p-4 mb-3 shadow-sm flex-row items-center"
+        onPress={() => handleSelectProject(item)}
+        onLongPress={() => handleCloseProject(item)}
+        testID={`project-item-${item.worktree}`}
+      >
+        <View className="w-10 h-10 rounded-lg bg-info/15 items-center justify-center mr-3">
+          <Text className="text-info text-lg font-bold">
+            {basename.charAt(0).toUpperCase()}
+          </Text>
+        </View>
+        <View className="flex-1">
+          <View className="flex-row items-center">
+            <Text className="text-lg font-semibold text-text flex-shrink">{basename}</Text>
+            {item.vcs === 'git' && (
+              <View className="bg-success/15 px-2 py-0.5 rounded ml-2">
+                <Text className="text-success text-xs font-medium">git</Text>
+              </View>
+            )}
+          </View>
+          <Text className="text-xs text-text-muted mt-1" numberOfLines={1}>
+            {item.worktree}
+          </Text>
+        </View>
+      </TouchableOpacity>
+    );
+  };
+
   return (
-    <SafeAreaView style={{ flex: 1 }}>
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-        <Text>Projects</Text>
+    <StyledSafeAreaView className="flex-1 bg-background" testID="projects-screen">
+      <View className="flex-row justify-between items-center p-4 bg-surface border-b border-border">
+        <TouchableOpacity
+          onPress={() => navigation.goBack()}
+          testID="back-button"
+        >
+          <Text className="text-base text-primary">← Back</Text>
+        </TouchableOpacity>
+        <View className="items-center">
+          <Text className="text-xl font-bold text-text">{server.name}</Text>
+          <Text className="text-xs text-text-muted">Projects</Text>
+        </View>
+        <TouchableOpacity
+          className="bg-primary px-4 py-2 rounded-lg"
+          onPress={() => navigation.navigate('SelectDirectory', { server })}
+          testID="open-folder-btn"
+        >
+          <Text className="text-white font-semibold">+ Open</Text>
+        </TouchableOpacity>
       </View>
-    </SafeAreaView>
+
+      {loading ? (
+        <View className="flex-1 justify-center items-center" testID="loading-indicator">
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      ) : (
+        <FlatList
+          data={listData}
+          renderItem={renderItem}
+          keyExtractor={(item: ListItem) =>
+            isAllSessions(item) ? '__all_sessions__' : item.worktree
+          }
+          contentContainerClassName="p-4"
+          testID="projects-list"
+          ListEmptyComponent={
+            <View className="items-center justify-center pt-16" testID="empty-projects">
+              <Text className="text-lg font-semibold text-text-muted mb-2">No projects</Text>
+              <Text className="text-sm text-text-subtle">Open a folder to get started</Text>
+            </View>
+          }
+        />
+      )}
+    </StyledSafeAreaView>
   );
 }

--- a/src/screens/projects/SelectDirectoryScreen.tsx
+++ b/src/screens/projects/SelectDirectoryScreen.tsx
@@ -62,12 +62,25 @@ export default function SelectDirectoryScreen() {
     })();
   }, []);
 
+  // Resolve a target directory into the API's { directory, path } params.
+  // The OpenCode file.list API uses `directory` as a filesystem root
+  // and `path` as a relative path within it (matching the web client pattern).
+  const scopeDirectory = (target: string): { directory: string; path: string } => {
+    const trimmed = target.replace(/\/+$/, '') || '/';
+    if (trimmed === '/') {
+      return { directory: '/', path: '' };
+    }
+    // Use root '/' as the base and the rest as relative path
+    return { directory: '/', path: trimmed.slice(1) };
+  };
+
   const loadEntries = async (directory: string) => {
     setLoading(true);
     setSearchResults(null);
     setSearchQuery('');
     try {
-      const files = await service.listFiles(directory, '.');
+      const { directory: dir, path } = scopeDirectory(directory);
+      const files = await service.listFiles(dir, path);
       // Only show directories, sorted alphabetically, hide hidden dirs
       const dirs = files
         .filter(f => f.type === 'directory' && !f.name.startsWith('.'))
@@ -111,7 +124,8 @@ export default function SelectDirectoryScreen() {
     }
     setSearching(true);
     try {
-      const results = await service.findDirectories(currentDirectory, query);
+      // Use '/' as directory root for broadest search, matching the web client
+      const results = await service.findDirectories('/', query);
       setSearchResults(results);
     } catch (error) {
       console.error('Error searching:', error);
@@ -119,7 +133,7 @@ export default function SelectDirectoryScreen() {
     } finally {
       setSearching(false);
     }
-  }, [currentDirectory]);
+  }, []);
 
   const handleSelectDirectory = useCallback(async (directory: string) => {
     const normalized = directory.replace(/\/+$/, '') || '/';

--- a/src/screens/projects/SelectDirectoryScreen.tsx
+++ b/src/screens/projects/SelectDirectoryScreen.tsx
@@ -62,25 +62,14 @@ export default function SelectDirectoryScreen() {
     })();
   }, []);
 
-  // Resolve a target directory into the API's { directory, path } params.
-  // The OpenCode file.list API uses `directory` as a filesystem root
-  // and `path` as a relative path within it (matching the web client pattern).
-  const scopeDirectory = (target: string): { directory: string; path: string } => {
-    const trimmed = target.replace(/\/+$/, '') || '/';
-    if (trimmed === '/') {
-      return { directory: '/', path: '' };
-    }
-    // Use root '/' as the base and the rest as relative path
-    return { directory: '/', path: trimmed.slice(1) };
-  };
-
   const loadEntries = async (directory: string) => {
     setLoading(true);
     setSearchResults(null);
     setSearchQuery('');
     try {
-      const { directory: dir, path } = scopeDirectory(directory);
-      const files = await service.listFiles(dir, path);
+      // The OpenCode file.list API takes `directory` as the directory to list.
+      // Pass the target directory directly — no path splitting needed.
+      const files = await service.listFiles(directory);
       // Only show directories, sorted alphabetically, hide hidden dirs
       const dirs = files
         .filter(f => f.type === 'directory' && !f.name.startsWith('.'))
@@ -124,8 +113,8 @@ export default function SelectDirectoryScreen() {
     }
     setSearching(true);
     try {
-      // Use '/' as directory root for broadest search, matching the web client
-      const results = await service.findDirectories('/', query);
+      // Search within the current directory
+      const results = await service.findDirectories(currentDirectory, query);
       setSearchResults(results);
     } catch (error) {
       console.error('Error searching:', error);
@@ -133,7 +122,7 @@ export default function SelectDirectoryScreen() {
     } finally {
       setSearching(false);
     }
-  }, []);
+  }, [currentDirectory]);
 
   const handleSelectDirectory = useCallback(async (directory: string) => {
     const normalized = directory.replace(/\/+$/, '') || '/';

--- a/src/screens/projects/SelectDirectoryScreen.tsx
+++ b/src/screens/projects/SelectDirectoryScreen.tsx
@@ -1,14 +1,247 @@
-import React from 'react';
-import { View, Text } from 'react-native';
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  TextInput,
+  Alert,
+  ActivityIndicator,
+} from 'react-native';
+import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { withUniwind } from 'uniwind';
+import { useStore } from '../../store';
+import { FileNode } from '../../types';
+import { RootStackParamList } from '../../navigation/types';
+import { OpenCodeService } from '../../services/opencode';
+import { useThemeColors } from '../../hooks/useThemeColors';
 
-// Placeholder — full implementation in next commit
+const StyledSafeAreaView = withUniwind(SafeAreaView);
+
+type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'SelectDirectory'>;
+type SelectDirectoryRouteProp = RouteProp<RootStackParamList, 'SelectDirectory'>;
+
 export default function SelectDirectoryScreen() {
-  return (
-    <SafeAreaView style={{ flex: 1 }}>
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-        <Text>Select Directory</Text>
+  const navigation = useNavigation<NavigationProp>();
+  const route = useRoute<SelectDirectoryRouteProp>();
+  const colors = useThemeColors();
+  const { server } = route.params;
+
+  const { openProject } = useStore();
+  const [service] = useState(() => new OpenCodeService(server));
+
+  const [currentDirectory, setCurrentDirectory] = useState<string>('');
+  const [homeDirectory, setHomeDirectory] = useState<string>('');
+  const [entries, setEntries] = useState<FileNode[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [pathInput, setPathInput] = useState<string>('');
+  const [searchQuery, setSearchQuery] = useState<string>('');
+  const [searchResults, setSearchResults] = useState<FileNode[] | null>(null);
+  const [searching, setSearching] = useState(false);
+
+  // Load initial path (home directory)
+  useEffect(() => {
+    (async () => {
+      try {
+        const pathInfo = await service.getPath();
+        if (pathInfo) {
+          const startDir = pathInfo.home || pathInfo.directory || '/';
+          setHomeDirectory(pathInfo.home || '/');
+          setCurrentDirectory(startDir);
+          setPathInput(startDir);
+          await loadEntries(startDir);
+        }
+      } catch (error) {
+        console.error('Error loading initial path:', error);
+        Alert.alert('Error', 'Failed to connect to server');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const loadEntries = async (directory: string) => {
+    setLoading(true);
+    setSearchResults(null);
+    setSearchQuery('');
+    try {
+      const files = await service.listFiles(directory, '.');
+      // Only show directories, sorted alphabetically, hide hidden dirs
+      const dirs = files
+        .filter(f => f.type === 'directory' && !f.name.startsWith('.'))
+        .sort((a, b) => a.name.localeCompare(b.name));
+      setEntries(dirs);
+    } catch (error) {
+      console.error('Error listing files:', error);
+      setEntries([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const navigateToDirectory = useCallback(async (directory: string) => {
+    const normalized = directory.replace(/\/+$/, '') || '/';
+    setCurrentDirectory(normalized);
+    setPathInput(normalized);
+    await loadEntries(normalized);
+  }, []);
+
+  const navigateUp = useCallback(async () => {
+    const parent = currentDirectory.replace(/\/[^/]+$/, '') || '/';
+    await navigateToDirectory(parent);
+  }, [currentDirectory]);
+
+  const handlePathSubmit = useCallback(async () => {
+    let path = pathInput.trim();
+    if (!path) return;
+    // Expand tilde
+    if (path.startsWith('~')) {
+      path = homeDirectory + path.slice(1);
+    }
+    await navigateToDirectory(path);
+  }, [pathInput, homeDirectory]);
+
+  const handleSearch = useCallback(async (query: string) => {
+    setSearchQuery(query);
+    if (!query.trim()) {
+      setSearchResults(null);
+      return;
+    }
+    setSearching(true);
+    try {
+      const results = await service.findDirectories(currentDirectory, query);
+      setSearchResults(results);
+    } catch (error) {
+      console.error('Error searching:', error);
+      setSearchResults([]);
+    } finally {
+      setSearching(false);
+    }
+  }, [currentDirectory]);
+
+  const handleSelectDirectory = useCallback(async (directory: string) => {
+    const normalized = directory.replace(/\/+$/, '') || '/';
+    // Add to local project list and navigate back
+    await openProject({
+      serverId: server.id,
+      worktree: normalized,
+    });
+    navigation.goBack();
+  }, [server.id]);
+
+  const displayEntries = searchResults ?? entries;
+
+  const renderEntry = ({ item }: { item: FileNode }): React.ReactElement => (
+    <TouchableOpacity
+      className="bg-surface rounded-lg p-3 mb-2 flex-row items-center"
+      onPress={() => navigateToDirectory(item.absolute)}
+      testID={`dir-entry-${item.name}`}
+    >
+      <View className="w-8 h-8 rounded bg-info/15 items-center justify-center mr-3">
+        <Text className="text-info text-sm font-bold">/</Text>
       </View>
-    </SafeAreaView>
+      <Text className="text-base text-text flex-1" numberOfLines={1}>
+        {searchResults ? item.absolute : item.name}
+      </Text>
+    </TouchableOpacity>
+  );
+
+  return (
+    <StyledSafeAreaView className="flex-1 bg-background" testID="select-directory-screen">
+      {/* Header */}
+      <View className="flex-row justify-between items-center p-4 bg-surface border-b border-border">
+        <TouchableOpacity
+          onPress={() => navigation.goBack()}
+          testID="back-button"
+        >
+          <Text className="text-base text-primary">Cancel</Text>
+        </TouchableOpacity>
+        <Text className="text-lg font-bold text-text">Open Folder</Text>
+        <TouchableOpacity
+          className="bg-primary px-4 py-2 rounded-lg"
+          onPress={() => handleSelectDirectory(currentDirectory)}
+          testID="select-btn"
+        >
+          <Text className="text-white font-semibold">Select</Text>
+        </TouchableOpacity>
+      </View>
+
+      {/* Path input */}
+      <View className="px-4 pt-3 pb-1">
+        <View className="flex-row items-center bg-surface rounded-lg border border-border">
+          <TextInput
+            className="flex-1 px-3 py-2.5 text-base text-text"
+            value={pathInput}
+            onChangeText={setPathInput}
+            onSubmitEditing={handlePathSubmit}
+            placeholder="Enter path..."
+            placeholderTextColor={colors.textSubtle}
+            autoCapitalize="none"
+            autoCorrect={false}
+            returnKeyType="go"
+            testID="path-input"
+          />
+          {currentDirectory !== '/' && (
+            <TouchableOpacity
+              className="px-3 py-2.5"
+              onPress={navigateUp}
+              testID="navigate-up-btn"
+            >
+              <Text className="text-primary font-semibold">↑ Up</Text>
+            </TouchableOpacity>
+          )}
+        </View>
+      </View>
+
+      {/* Search input */}
+      <View className="px-4 pt-2 pb-1">
+        <TextInput
+          className="bg-surface rounded-lg border border-border px-3 py-2.5 text-base text-text"
+          value={searchQuery}
+          onChangeText={handleSearch}
+          placeholder="Search directories..."
+          placeholderTextColor={colors.textSubtle}
+          autoCapitalize="none"
+          autoCorrect={false}
+          testID="search-input"
+        />
+      </View>
+
+      {/* Current path breadcrumb */}
+      <View className="px-4 py-2">
+        <Text className="text-xs text-text-muted" numberOfLines={1}>
+          {currentDirectory}
+        </Text>
+      </View>
+
+      {/* Directory listing */}
+      {loading || searching ? (
+        <View className="flex-1 justify-center items-center" testID="loading-indicator">
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      ) : (
+        <FlatList
+          data={displayEntries}
+          renderItem={renderEntry}
+          keyExtractor={(item: FileNode) => item.absolute}
+          contentContainerClassName="px-4 pb-4"
+          testID="directory-list"
+          ListEmptyComponent={
+            <View className="items-center justify-center pt-16" testID="empty-directory">
+              <Text className="text-lg font-semibold text-text-muted mb-2">
+                {searchResults ? 'No matching directories' : 'Empty directory'}
+              </Text>
+              <Text className="text-sm text-text-subtle">
+                {searchResults
+                  ? 'Try a different search term'
+                  : 'Select this directory or navigate elsewhere'}
+              </Text>
+            </View>
+          }
+        />
+      )}
+    </StyledSafeAreaView>
   );
 }

--- a/src/screens/projects/SelectDirectoryScreen.tsx
+++ b/src/screens/projects/SelectDirectoryScreen.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+// Placeholder — full implementation in next commit
+export default function SelectDirectoryScreen() {
+  return (
+    <SafeAreaView style={{ flex: 1 }}>
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <Text>Select Directory</Text>
+      </View>
+    </SafeAreaView>
+  );
+}

--- a/src/screens/projects/SelectDirectoryScreen.tsx
+++ b/src/screens/projects/SelectDirectoryScreen.tsx
@@ -41,6 +41,22 @@ export default function SelectDirectoryScreen() {
   const [searchResults, setSearchResults] = useState<FileNode[] | null>(null);
   const [searching, setSearching] = useState(false);
 
+  // Convert relative paths from find/file API into FileNode-like objects
+  const pathsToFileNodes = (directory: string, paths: string[]): FileNode[] => {
+    return paths.map(p => {
+      const trimmed = p.replace(/\/+$/, '');
+      const name = trimmed.split('/').pop() || trimmed;
+      const absolute = `${directory.replace(/\/+$/, '')}/${trimmed}`;
+      return {
+        name,
+        path: trimmed,
+        absolute,
+        type: 'directory' as const,
+        ignored: false,
+      };
+    });
+  };
+
   // Load initial path (home directory)
   useEffect(() => {
     (async () => {
@@ -113,9 +129,9 @@ export default function SelectDirectoryScreen() {
     }
     setSearching(true);
     try {
-      // Search within the current directory
+      // Search within the current directory — returns relative path strings
       const results = await service.findDirectories(currentDirectory, query);
-      setSearchResults(results);
+      setSearchResults(pathsToFileNodes(currentDirectory, results));
     } catch (error) {
       console.error('Error searching:', error);
       setSearchResults([]);

--- a/src/screens/servers/ServersScreen.tsx
+++ b/src/screens/servers/ServersScreen.tsx
@@ -46,7 +46,7 @@ export default function ServersScreen() {
 
   const handleSelectServer = (server: Server) => {
     selectServer(server);
-    navigation.navigate('Sessions', { server });
+    navigation.navigate('Projects', { server });
   };
 
   const renderServer = ({ item }: { item: Server }): React.ReactElement => {

--- a/src/screens/sessions/NewSessionScreen.tsx
+++ b/src/screens/sessions/NewSessionScreen.tsx
@@ -26,7 +26,7 @@ export default function NewSessionScreen() {
   const navigation = useNavigation<NavigationProp>();
   const route = useRoute<NewSessionRouteProp>();
   const colors = useThemeColors();
-  const { server } = route.params;
+  const { server, project } = route.params;
   
   const { addSession } = useStore();
   const [newSessionTitle, setNewSessionTitle] = useState('');
@@ -41,7 +41,7 @@ export default function NewSessionScreen() {
 
     setLoading(true);
     try {
-      const remoteSession = await service.createSession(newSessionTitle);
+      const remoteSession = await service.createSession(newSessionTitle, project?.worktree);
       
       if (remoteSession) {
         const session: Session = {

--- a/src/screens/sessions/SessionsScreen.tsx
+++ b/src/screens/sessions/SessionsScreen.tsx
@@ -14,10 +14,15 @@ import { withUniwind } from 'uniwind';
 import { useStore } from '../../store';
 
 const StyledSafeAreaView = withUniwind(SafeAreaView);
-import { Session } from '../../types';
+import { Session, Project } from '../../types';
 import { RootStackParamList } from '../../navigation/types';
 import { OpenCodeService } from '../../services/opencode';
 import { useThemeColors } from '../../hooks/useThemeColors';
+
+function getDirectoryBasename(worktree: string): string {
+  const parts = worktree.replace(/\/+$/, '').split('/');
+  return parts[parts.length - 1] || worktree;
+}
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'Sessions'>;
 type SessionsRouteProp = RouteProp<RootStackParamList, 'Sessions'>;
@@ -26,11 +31,15 @@ export default function SessionsScreen() {
   const navigation = useNavigation<NavigationProp>();
   const route = useRoute<SessionsRouteProp>();
   const colors = useThemeColors();
-  const { server } = route.params;
+  const { server, project } = route.params;
   
   const { sessions, addSession, deleteSession, selectSession, loadSessions } = useStore();
   const [loading, setLoading] = useState(false);
   const [service] = useState(() => new OpenCodeService(server));
+
+  const headerTitle = project
+    ? getDirectoryBasename(project.worktree)
+    : 'All Sessions';
 
   useEffect(() => {
     loadSessionsFromServer();
@@ -39,7 +48,7 @@ export default function SessionsScreen() {
   const loadSessionsFromServer = async () => {
     setLoading(true);
     try {
-      const remoteSessions = await service.getSessions();
+      const remoteSessions = await service.getSessions(project?.worktree);
       
       await loadSessions(server.id);
       
@@ -124,12 +133,12 @@ export default function SessionsScreen() {
           <Text className="text-base text-primary">← Back</Text>
         </TouchableOpacity>
         <View className="items-center">
-          <Text className="text-xl font-bold text-text">{server.name}</Text>
-          <Text className="text-xs text-text-muted">Sessions</Text>
+          <Text className="text-xl font-bold text-text">{headerTitle}</Text>
+          <Text className="text-xs text-text-muted">{server.name}</Text>
         </View>
         <TouchableOpacity 
           className="bg-primary px-4 py-2 rounded-lg"
-          onPress={() => navigation.navigate('NewSession', { server })}
+          onPress={() => navigation.navigate('NewSession', { server, project })}
           testID="create-session-btn"
         >
           <Text className="text-white font-semibold">+ New</Text>

--- a/src/screens/sessions/SessionsScreen.tsx
+++ b/src/screens/sessions/SessionsScreen.tsx
@@ -133,16 +133,16 @@ export default function SessionsScreen() {
         >
           <Text className="text-base text-primary">← Back</Text>
         </TouchableOpacity>
-        <View className="items-center">
-          <Text className="text-xl font-bold text-text">{headerTitle}</Text>
-          <Text className="text-xs text-text-muted">{server.name}</Text>
+        <View className="flex-1 items-center mx-3">
+          <Text className="text-xl font-bold text-text" numberOfLines={1}>{headerTitle}</Text>
+          <Text className="text-xs text-text-muted" numberOfLines={1}>{server.name}</Text>
         </View>
         <TouchableOpacity 
           className="bg-primary px-4 py-2 rounded-lg"
           onPress={() => navigation.navigate('NewSession', { server, project })}
           testID="create-session-btn"
         >
-          <Text className="text-white font-semibold">+ New</Text>
+          <Text className="text-white font-semibold">New</Text>
         </TouchableOpacity>
       </View>
 

--- a/src/screens/sessions/SessionsScreen.tsx
+++ b/src/screens/sessions/SessionsScreen.tsx
@@ -35,6 +35,7 @@ export default function SessionsScreen() {
   
   const { sessions, addSession, deleteSession, selectSession, loadSessions } = useStore();
   const [loading, setLoading] = useState(false);
+  const [showSubAgents, setShowSubAgents] = useState(false);
   const [service] = useState(() => new OpenCodeService(server));
 
   const headerTitle = project
@@ -145,13 +146,29 @@ export default function SessionsScreen() {
         </TouchableOpacity>
       </View>
 
+      {/* Sub-agent toggle */}
+      <View className="flex-row items-center justify-between px-4 py-2 bg-surface border-b border-border">
+        <Text className="text-sm text-text-muted">Show sub-agent sessions</Text>
+        <TouchableOpacity
+          className={`px-3 py-1 rounded-full ${showSubAgents ? 'bg-primary' : 'bg-border'}`}
+          onPress={() => setShowSubAgents(!showSubAgents)}
+          testID="toggle-subagents-btn"
+        >
+          <Text className={`text-xs font-semibold ${showSubAgents ? 'text-white' : 'text-text-muted'}`}>
+            {showSubAgents ? 'ON' : 'OFF'}
+          </Text>
+        </TouchableOpacity>
+      </View>
+
       {loading ? (
         <View className="flex-1 justify-center items-center" testID="loading-indicator">
           <ActivityIndicator size="large" color={colors.primary} />
         </View>
       ) : (
         <FlatList
-          data={[...new Map(sessions.map(s => [s.id, s])).values()].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())}
+          data={[...new Map(sessions.map(s => [s.id, s])).values()]
+            .filter(s => showSubAgents || !s.parentId)
+            .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())}
           renderItem={renderSession}
           keyExtractor={(item: Session) => item.id}
           contentContainerClassName="p-4"

--- a/src/services/opencode.ts
+++ b/src/services/opencode.ts
@@ -1,4 +1,4 @@
-import { Server, Session, GitFile } from '../types';
+import { Server, Session, GitFile, Project, FileNode } from '../types';
 import EventSource from 'react-native-sse';
 import base64 from 'base-64';
 
@@ -101,6 +101,8 @@ export interface Message {
 // Raw API session shape (different from our local Session type)
 interface ApiSession {
   id: string;
+  projectID?: string;
+  directory?: string;
   title: string;
   time: {
     created: number;
@@ -108,6 +110,36 @@ interface ApiSession {
   };
   version?: string;
   parentID?: string;
+}
+
+// Raw API project shape
+interface ApiProject {
+  id: string;
+  worktree: string;
+  vcsDir?: string;
+  vcs?: 'git';
+  time: {
+    created: number;
+    initialized?: number;
+  };
+}
+
+// Raw API path shape
+interface ApiPath {
+  home: string;
+  directory: string;
+  state?: string;
+  config?: string;
+  worktree?: string;
+}
+
+// Raw API file node shape
+interface ApiFileNode {
+  name: string;
+  path: string;
+  absolute: string;
+  type: 'file' | 'directory';
+  ignored: boolean;
 }
 
 interface FileDiff {
@@ -128,9 +160,14 @@ export class OpenCodeService {
     this.password = server.apiKey;
   }
 
-  async getSessions(): Promise<Session[]> {
+  async getSessions(directory?: string): Promise<Session[]> {
     try {
-      const response = await fetch(`${this.baseUrl}/session`, {
+      const params = new URLSearchParams();
+      if (directory) params.append('directory', directory);
+      const queryString = params.toString();
+      const url = `${this.baseUrl}/session${queryString ? `?${queryString}` : ''}`;
+
+      const response = await fetch(url, {
         headers: this.getHeaders(),
       });
       if (!response.ok) throw new Error('Failed to fetch sessions');
@@ -140,6 +177,8 @@ export class OpenCodeService {
       return data.map(apiSession => ({
         id: apiSession.id,
         serverId: '', // Will be set by the caller
+        projectId: apiSession.projectID,
+        directory: apiSession.directory,
         title: apiSession.title,
         createdAt: apiSession.time?.created
           ? new Date(apiSession.time.created * 1000).toISOString()
@@ -154,9 +193,14 @@ export class OpenCodeService {
     }
   }
 
-  async createSession(title: string): Promise<Session | null> {
+  async createSession(title: string, directory?: string): Promise<Session | null> {
     try {
-      const response = await fetch(`${this.baseUrl}/session`, {
+      const params = new URLSearchParams();
+      if (directory) params.append('directory', directory);
+      const queryString = params.toString();
+      const url = `${this.baseUrl}/session${queryString ? `?${queryString}` : ''}`;
+
+      const response = await fetch(url, {
         method: 'POST',
         headers: this.getHeaders(),
         body: JSON.stringify({ title }),
@@ -468,6 +512,88 @@ export class OpenCodeService {
       return response.json();
     } catch (error) {
       console.error('Error searching text:', error);
+      return [];
+    }
+  }
+
+  async getProjects(): Promise<Project[]> {
+    try {
+      const response = await fetch(`${this.baseUrl}/project`, {
+        headers: this.getHeaders(),
+      });
+      if (!response.ok) throw new Error('Failed to fetch projects');
+      const data: ApiProject[] = await response.json();
+      return data.map(apiProject => ({
+        id: apiProject.id,
+        serverId: '', // Will be set by the caller
+        worktree: apiProject.worktree,
+        vcs: apiProject.vcs,
+        vcsDir: apiProject.vcsDir,
+        createdAt: apiProject.time?.created
+          ? new Date(apiProject.time.created * 1000).toISOString()
+          : undefined,
+        initializedAt: apiProject.time?.initialized
+          ? new Date(apiProject.time.initialized * 1000).toISOString()
+          : undefined,
+      }));
+    } catch (error) {
+      console.error('Error fetching projects:', error);
+      return [];
+    }
+  }
+
+  async getPath(directory?: string): Promise<ApiPath | null> {
+    try {
+      const params = new URLSearchParams();
+      if (directory) params.append('directory', directory);
+      const queryString = params.toString();
+      const url = `${this.baseUrl}/path${queryString ? `?${queryString}` : ''}`;
+
+      const response = await fetch(url, {
+        headers: this.getHeaders(),
+      });
+      if (!response.ok) throw new Error('Failed to fetch path');
+      return response.json();
+    } catch (error) {
+      console.error('Error fetching path:', error);
+      return null;
+    }
+  }
+
+  async listFiles(directory: string, path?: string): Promise<FileNode[]> {
+    try {
+      const params = new URLSearchParams();
+      params.append('directory', directory);
+      if (path) params.append('path', path);
+      const url = `${this.baseUrl}/file/list?${params.toString()}`;
+
+      const response = await fetch(url, {
+        headers: this.getHeaders(),
+      });
+      if (!response.ok) throw new Error('Failed to list files');
+      return response.json();
+    } catch (error) {
+      console.error('Error listing files:', error);
+      return [];
+    }
+  }
+
+  async findDirectories(directory: string, query: string, limit: number = 50): Promise<FileNode[]> {
+    try {
+      const params = new URLSearchParams();
+      params.append('directory', directory);
+      params.append('query', query);
+      params.append('type', 'directory');
+      params.append('limit', limit.toString());
+      const url = `${this.baseUrl}/find/files?${params.toString()}`;
+
+      const response = await fetch(url, {
+        headers: this.getHeaders(),
+      });
+      if (!response.ok) throw new Error('Failed to find directories');
+      return response.json();
+    } catch (error) {
+      console.error('Error finding directories:', error);
       return [];
     }
   }

--- a/src/services/opencode.ts
+++ b/src/services/opencode.ts
@@ -179,6 +179,7 @@ export class OpenCodeService {
         serverId: '', // Will be set by the caller
         projectId: apiSession.projectID,
         directory: apiSession.directory,
+        parentId: apiSession.parentID,
         title: apiSession.title,
         createdAt: apiSession.time?.created
           ? new Date(apiSession.time.created * 1000).toISOString()

--- a/src/services/opencode.ts
+++ b/src/services/opencode.ts
@@ -607,12 +607,12 @@ export class OpenCodeService {
     }
   }
 
-  async listFiles(directory: string, path?: string): Promise<FileNode[]> {
+  async listFiles(directory: string, path: string = '.'): Promise<FileNode[]> {
     try {
       const params = new URLSearchParams();
       params.append('directory', directory);
-      if (path) params.append('path', path);
-      const url = `${this.baseUrl}/file/list?${params.toString()}`;
+      params.append('path', path);
+      const url = `${this.baseUrl}/file?${params.toString()}`;
 
       const response = await fetch(url, {
         headers: this.getHeaders(),
@@ -625,14 +625,14 @@ export class OpenCodeService {
     }
   }
 
-  async findDirectories(directory: string, query: string, limit: number = 50): Promise<FileNode[]> {
+  async findDirectories(directory: string, query: string, limit: number = 50): Promise<string[]> {
     try {
       const params = new URLSearchParams();
       params.append('directory', directory);
       params.append('query', query);
       params.append('type', 'directory');
       params.append('limit', limit.toString());
-      const url = `${this.baseUrl}/find/files?${params.toString()}`;
+      const url = `${this.baseUrl}/find/file?${params.toString()}`;
 
       const response = await fetch(url, {
         headers: this.getHeaders(),

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Server, Session, ChatMessage, GitFile, FileAnnotation } from '../types';
+import { Server, Session, ChatMessage, GitFile, FileAnnotation, Project } from '../types';
 
 type ThemeMode = 'light' | 'dark' | 'system';
 
@@ -18,6 +18,15 @@ interface AppState {
   deleteServer: (id: string) => Promise<void>;
   selectServer: (server: Server | null) => void;
   loadServers: () => Promise<void>;
+
+  // Projects
+  projects: Project[];
+  selectedProject: Project | null;
+  openProject: (project: Project) => Promise<void>;
+  closeProject: (serverId: string, worktree: string) => Promise<void>;
+  selectProject: (project: Project | null) => void;
+  enrichProjects: (serverId: string, apiProjects: Project[]) => Promise<void>;
+  loadProjects: (serverId: string) => Promise<void>;
 
   // Sessions
   sessions: Session[];
@@ -49,6 +58,7 @@ interface AppState {
 }
 
 const SERVERS_KEY = '@opencode_servers';
+const PROJECTS_KEY = '@opencode_projects';
 const SESSIONS_KEY = '@opencode_sessions';
 const MESSAGES_KEY = '@opencode_messages';
 const THEME_KEY = '@opencode_theme';
@@ -104,6 +114,57 @@ export const useStore = create<AppState>((set, get) => ({
     const data = await AsyncStorage.getItem(SERVERS_KEY);
     if (data) {
       set({ servers: JSON.parse(data) });
+    }
+  },
+
+  // Projects
+  projects: [],
+  selectedProject: null,
+
+  openProject: async (project: Project) => {
+    const existing = get().projects;
+    // Deduplicate by worktree + serverId
+    if (existing.find(p => p.worktree === project.worktree && p.serverId === project.serverId)) {
+      return;
+    }
+    const projects = [...existing, project];
+    set({ projects });
+    await AsyncStorage.setItem(`${PROJECTS_KEY}_${project.serverId}`, JSON.stringify(projects));
+  },
+
+  closeProject: async (serverId: string, worktree: string) => {
+    const projects = get().projects.filter(p => !(p.worktree === worktree && p.serverId === serverId));
+    set({ projects });
+    await AsyncStorage.setItem(`${PROJECTS_KEY}_${serverId}`, JSON.stringify(projects));
+  },
+
+  selectProject: (project: Project | null) => set({ selectedProject: project }),
+
+  enrichProjects: async (serverId: string, apiProjects: Project[]) => {
+    const current = get().projects;
+    const enriched = current.map(p => {
+      if (p.serverId !== serverId) return p;
+      const match = apiProjects.find(ap => ap.worktree === p.worktree);
+      if (!match) return p;
+      return {
+        ...p,
+        id: match.id,
+        vcs: match.vcs,
+        vcsDir: match.vcsDir,
+        createdAt: match.createdAt ?? p.createdAt,
+        initializedAt: match.initializedAt ?? p.initializedAt,
+      };
+    });
+    set({ projects: enriched });
+    await AsyncStorage.setItem(`${PROJECTS_KEY}_${serverId}`, JSON.stringify(enriched));
+  },
+
+  loadProjects: async (serverId: string) => {
+    const data = await AsyncStorage.getItem(`${PROJECTS_KEY}_${serverId}`);
+    if (data) {
+      set({ projects: JSON.parse(data) });
+    } else {
+      set({ projects: [] });
     }
   },
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,6 +48,7 @@ export interface Session {
   serverId: string;
   projectId?: string;
   directory?: string;
+  parentId?: string;
   title: string;
   createdAt: string;
   updatedAt?: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,9 +46,30 @@ export interface Server {
 export interface Session {
   id: string;
   serverId: string;
+  projectId?: string;
+  directory?: string;
   title: string;
   createdAt: string;
   updatedAt?: string;
+}
+
+export interface Project {
+  id?: string;
+  serverId: string;
+  worktree: string;
+  name?: string;
+  vcs?: 'git';
+  vcsDir?: string;
+  createdAt?: string;
+  initializedAt?: string;
+}
+
+export interface FileNode {
+  name: string;
+  path: string;
+  absolute: string;
+  type: 'file' | 'directory';
+  ignored: boolean;
 }
 
 export interface ChatMessageToolCall {


### PR DESCRIPTION
## Summary

Closes #4

Adds an intermediate **Projects** layer to the navigation flow: `Servers → Projects → Sessions → SessionDetail`.

- **ProjectsScreen** — lists locally-tracked projects enriched with metadata from the OpenCode API (`GET /project`). Includes an "All Sessions" pseudo-project as the first item. Auto-discovers projects already known to the server.
- **SelectDirectoryScreen** — directory browser using the OpenCode file API (`GET /file/list`, `GET /find/files`). No SSH dependency. Mirrors the approach used by the official OpenCode web client.
- **SessionsScreen** — updated to filter sessions by project directory via `?directory=` query param on `GET /session` and `POST /session`.

## Key design decisions

- **No SSH required** — directory browsing uses the native OpenCode HTTP API (`/file/list`, `/find/files`, `/path`), matching how the official web client works.
- **Client-side project list** — "opening" a project adds its worktree to a locally-persisted list (AsyncStorage). Server metadata is merged in from `GET /project`. This matches the web client pattern where there is no `POST /project` endpoint.
- **Session scoping via `?directory=`** — most OpenCode API endpoints accept a `?directory=` query param to scope operations to a specific project directory.

## Changes

| File | Description |
| --- | --- |
| `src/types/index.ts` | Add `Project`, `FileNode` types; add `projectId`/`directory` to `Session` |
| `src/services/opencode.ts` | Add project/file API methods; update session methods with `?directory=` |
| `src/store/index.ts` | Add projects slice (open, close, enrich, persist) |
| `src/navigation/types.ts` | Add `Projects`, `SelectDirectory` screens; update `Sessions` params |
| `App.tsx` | Register new screens |
| `src/screens/projects/ProjectsScreen.tsx` | **New** — project list with "All Sessions" |
| `src/screens/projects/SelectDirectoryScreen.tsx` | **New** — API-based directory browser |
| `src/screens/sessions/SessionsScreen.tsx` | Add project filtering |
| `src/screens/sessions/NewSessionScreen.tsx` | Scope new sessions to project directory |
| `src/screens/servers/ServersScreen.tsx` | Navigate to Projects instead of Sessions |

## Not included (future work)

- Project reordering (drag-to-sort)
- Workspace/branch support
- Project editing (name, icon, commands)
- Session archiving