### PR TITLE
feat: make 'Other' option always available in questions

### DIFF
--- a/src/components/chat/ChatTab.tsx
+++ b/src/components/chat/ChatTab.tsx
@@ -21,13 +21,14 @@ import * as DocumentPicker from 'expo-document-picker';
 import * as ImagePicker from 'expo-image-picker';
 import * as FileSystem from 'expo-file-system/legacy';
 import { useStore } from '../../store';
-import { Agent, ChatMessage, ChatMessagePart, ChatQuestion, MessageAttachment, Server, Session } from '../../types';
-import { OpenCodeService, Message as ApiMessage, ToolMetadata, QuestionAskedEvent } from '../../services/opencode';
+import { Agent, ChatMessage, ChatMessagePart, ChatPermission, ChatQuestion, MessageAttachment, Server, Session } from '../../types';
+import { OpenCodeService, Message as ApiMessage, ToolMetadata, QuestionAskedEvent, PermissionAskedEvent } from '../../services/opencode';
 import { useThemeColors } from '../../hooks/useThemeColors';
 import { useAppStateRefresh } from '../../hooks/useAppStateRefresh';
 import MarkdownRenderer from './MarkdownRenderer';
 import ToolCallDisplay from './ToolCallDisplay';
 import QuestionDisplay from './QuestionDisplay';
+import PermissionDisplay from './PermissionDisplay';
 
 const StyledImage = withUniwind(Image);
 const StyledActivityIndicator = withUniwind(ActivityIndicator);
@@ -120,6 +121,7 @@ export default function ChatTab({ session, server }: ChatTabProps) {
   const [initialLoading, setInitialLoading] = useState(true);
   const [streamingText, setStreamingText] = useState('');
   const [pendingQuestion, setPendingQuestion] = useState<QuestionAskedEvent | null>(null);
+  const [pendingPermission, setPendingPermission] = useState<PermissionAskedEvent | null>(null);
   const flatListRef = useRef<FlatList>(null);
   const [service] = useState(() => new OpenCodeService(server));
 
@@ -363,6 +365,9 @@ export default function ChatTab({ session, server }: ChatTabProps) {
           onQuestionAsked: (event) => {
             setPendingQuestion(event);
           },
+          onPermissionAsked: (event) => {
+            setPendingPermission(event);
+          },
           onComplete: async () => {
             // Fetch final messages from server to get rich parts
             // (tool calls, reasoning blocks, attachments, etc.)
@@ -414,6 +419,40 @@ export default function ChatTab({ session, server }: ChatTabProps) {
     } catch (error) {
       console.error('Error answering question:', error);
       Alert.alert('Error', 'Failed to send answer');
+    }
+  };
+
+  /**
+   * Approve a pending permission request from the server.
+   */
+  const handleApprovePermission = async (requestId: string) => {
+    setPendingPermission(null);
+
+    try {
+      const ok = await service.approvePermission(requestId);
+      if (!ok) {
+        Alert.alert('Error', 'Failed to approve permission');
+      }
+    } catch (error) {
+      console.error('Error approving permission:', error);
+      Alert.alert('Error', 'Failed to approve permission');
+    }
+  };
+
+  /**
+   * Deny a pending permission request from the server.
+   */
+  const handleDenyPermission = async (requestId: string) => {
+    setPendingPermission(null);
+
+    try {
+      const ok = await service.denyPermission(requestId);
+      if (!ok) {
+        Alert.alert('Error', 'Failed to deny permission');
+      }
+    } catch (error) {
+      console.error('Error denying permission:', error);
+      Alert.alert('Error', 'Failed to deny permission');
     }
   };
 
@@ -595,13 +634,13 @@ export default function ChatTab({ session, server }: ChatTabProps) {
           </View>
         }
         ListFooterComponent={
-          streamingText || pendingQuestion ? (
+          streamingText || pendingQuestion || pendingPermission ? (
             <View>
               {streamingText ? (
                 <View className="self-start w-full py-2" testID="streaming-message">
                   <Text className="text-text-muted font-semibold text-xs mb-1 px-1">Assistant</Text>
                   <MarkdownRenderer content={streamingText} />
-                  {!pendingQuestion && <StyledActivityIndicator className="mt-2" />}
+                  {!pendingQuestion && !pendingPermission && <StyledActivityIndicator className="mt-2" />}
                 </View>
               ) : null}
               {pendingQuestion && pendingQuestion.questions.map((q, idx) => (
@@ -622,6 +661,19 @@ export default function ChatTab({ session, server }: ChatTabProps) {
                   }}
                 />
               ))}
+              {pendingPermission && (
+                <PermissionDisplay
+                  key={pendingPermission.id}
+                  permission={{
+                    requestId: pendingPermission.id,
+                    message: pendingPermission.permission.message,
+                    header: pendingPermission.permission.header,
+                    details: pendingPermission.permission.details,
+                  }}
+                  onApprove={() => handleApprovePermission(pendingPermission.id)}
+                  onDeny={() => handleDenyPermission(pendingPermission.id)}
+                />
+              )}
             </View>
           ) : null
         }

--- a/src/components/chat/PermissionDisplay.tsx
+++ b/src/components/chat/PermissionDisplay.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity } from 'react-native';
+import { ChatPermission } from '../../types';
+import { useThemeColors } from '../../hooks/useThemeColors';
+
+interface PermissionDisplayProps {
+  permission: ChatPermission;
+  /** Called when user approves the permission */
+  onApprove: () => void;
+  /** Called when user denies the permission */
+  onDeny: () => void;
+  answered?: boolean;
+}
+
+export default function PermissionDisplay({ 
+  permission, 
+  onApprove, 
+  onDeny, 
+  answered = false 
+}: PermissionDisplayProps) {
+  const colors = useThemeColors();
+  const [submitted, setSubmitted] = useState(false);
+
+  const isDisabled = answered || submitted;
+
+  const handleApprove = () => {
+    if (isDisabled) return;
+    setSubmitted(true);
+    onApprove();
+  };
+
+  const handleDeny = () => {
+    if (isDisabled) return;
+    setSubmitted(true);
+    onDeny();
+  };
+
+  return (
+    <View className="bg-surface-elevated p-4 rounded-lg border border-border mt-2">
+      {/* Header */}
+      {permission.header ? (
+        <Text className="text-text-muted text-xs font-semibold uppercase tracking-wide mb-1">
+          {permission.header}
+        </Text>
+      ) : null}
+
+      {/* Permission message */}
+      <Text className="text-text font-medium mb-2">{permission.message}</Text>
+
+      {/* Details (if provided) */}
+      {permission.details ? (
+        <Text className="text-text-subtle text-sm mb-3">{permission.details}</Text>
+      ) : null}
+
+      {/* Action buttons */}
+      <View className="flex-row gap-2 mt-2">
+        <TouchableOpacity
+          onPress={handleDeny}
+          disabled={isDisabled}
+          className={`flex-1 px-4 py-3 rounded-md border border-border bg-surface ${
+            isDisabled ? 'opacity-50' : ''
+          }`}
+        >
+          <Text className="text-text font-medium text-center">Deny</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={handleApprove}
+          disabled={isDisabled}
+          className={`flex-1 px-4 py-3 rounded-md bg-primary ${
+            isDisabled ? 'opacity-50' : ''
+          }`}
+        >
+          <Text className="text-on-primary font-medium text-center">Approve</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}

--- a/src/components/chat/QuestionDisplay.tsx
+++ b/src/components/chat/QuestionDisplay.tsx
@@ -106,33 +106,31 @@ export default function QuestionDisplay({ question, onAnswer, answered = false }
         </View>
       )}
 
-      {/* Custom text input (when custom flag is set, or no options at all) */}
-      {(question.custom || !hasOptions) && (
-        <View className="flex-row items-center mb-2">
-          <TextInput
-            value={customText}
-            onChangeText={setCustomText}
-            editable={!isDisabled}
-            placeholder="Type your answer..."
-            placeholderTextColor={colors.textSubtle}
-            className="flex-1 bg-surface border border-border rounded-md px-3 py-2 text-text mr-2"
-            onSubmitEditing={hasOptions ? handleSubmitMultiple : handleSubmitCustomOnly}
-            returnKeyType="send"
-          />
-          {/* Show send button for custom-only (no options) */}
-          {!hasOptions && (
-            <TouchableOpacity
-              onPress={handleSubmitCustomOnly}
-              disabled={isDisabled || !customText.trim()}
-              className={`px-4 py-2 rounded-md bg-primary justify-center ${
-                isDisabled || !customText.trim() ? 'opacity-50' : ''
-              }`}
-            >
-              <Text className="text-on-primary font-medium">Send</Text>
-            </TouchableOpacity>
-          )}
-        </View>
-      )}
+      {/* Custom text input - always available for "Other" option */}
+      <View className="flex-row items-center mb-2">
+        <TextInput
+          value={customText}
+          onChangeText={setCustomText}
+          editable={!isDisabled}
+          placeholder="Other (type your answer)..."
+          placeholderTextColor={colors.textSubtle}
+          className="flex-1 bg-surface border border-border rounded-md px-3 py-2 text-text mr-2"
+          onSubmitEditing={hasOptions ? handleSubmitMultiple : handleSubmitCustomOnly}
+          returnKeyType="send"
+        />
+        {/* Show send button for custom-only (no options) */}
+        {!hasOptions && (
+          <TouchableOpacity
+            onPress={handleSubmitCustomOnly}
+            disabled={isDisabled || !customText.trim()}
+            className={`px-4 py-2 rounded-md bg-primary justify-center ${
+              isDisabled || !customText.trim() ? 'opacity-50' : ''
+            }`}
+          >
+            <Text className="text-on-primary font-medium">Send</Text>
+          </TouchableOpacity>
+        )}
+      </View>
 
       {/* Submit button for multi-select mode */}
       {question.multiple && hasOptions && (

--- a/src/components/chat/QuestionDisplay.tsx
+++ b/src/components/chat/QuestionDisplay.tsx
@@ -107,30 +107,32 @@ export default function QuestionDisplay({ question, onAnswer, answered = false }
       )}
 
       {/* Custom text input - always available for "Other" option */}
-      <View className="flex-row items-center mb-2">
+      <TouchableOpacity
+        onPress={() => {
+          // In single-select mode with options, allow clicking to submit custom text
+          if (!question.multiple && hasOptions && customText.trim()) {
+            handleSubmitCustomOnly();
+          }
+        }}
+        disabled={isDisabled || !customText.trim() || question.multiple || !hasOptions}
+        activeOpacity={!question.multiple && hasOptions && customText.trim() ? 0.7 : 1}
+        className={`p-3 rounded-md border mb-2 ${
+          customText.trim()
+            ? 'bg-primary/10 border-primary'
+            : 'bg-surface border-border'
+        } ${isDisabled && !customText.trim() ? 'opacity-50' : ''}`}
+      >
         <TextInput
           value={customText}
           onChangeText={setCustomText}
           editable={!isDisabled}
           placeholder="Other (type your answer)..."
           placeholderTextColor={colors.textSubtle}
-          className="flex-1 bg-surface border border-border rounded-md px-3 py-2 text-text mr-2"
-          onSubmitEditing={hasOptions ? handleSubmitMultiple : handleSubmitCustomOnly}
+          className={`${customText.trim() ? 'text-primary' : 'text-text'} font-medium`}
+          onSubmitEditing={hasOptions && question.multiple ? handleSubmitMultiple : handleSubmitCustomOnly}
           returnKeyType="send"
         />
-        {/* Show send button for custom-only (no options) */}
-        {!hasOptions && (
-          <TouchableOpacity
-            onPress={handleSubmitCustomOnly}
-            disabled={isDisabled || !customText.trim()}
-            className={`px-4 py-2 rounded-md bg-primary justify-center ${
-              isDisabled || !customText.trim() ? 'opacity-50' : ''
-            }`}
-          >
-            <Text className="text-on-primary font-medium">Send</Text>
-          </TouchableOpacity>
-        )}
-      </View>
+      </TouchableOpacity>
 
       {/* Submit button for multi-select mode */}
       {question.multiple && hasOptions && (

--- a/src/services/opencode.ts
+++ b/src/services/opencode.ts
@@ -92,6 +92,21 @@ export interface QuestionAskedEvent {
   tool?: { messageID: string; callID: string };
 }
 
+/** Permission request item */
+export interface PermissionItem {
+  message: string;
+  header?: string;
+  details?: string;
+}
+
+/** Payload from the server's `permission.asked` SSE event */
+export interface PermissionAskedEvent {
+  id: string;           // requestID – used for approve/deny
+  sessionID: string;
+  permission: PermissionItem;
+  tool?: { messageID: string; callID: string };
+}
+
 export interface ToolMetadata {
   title?: string;
   time?: { start?: number; end?: number };
@@ -391,6 +406,7 @@ export class OpenCodeService {
       onTextDelta?: (delta: string) => void;
       onPartUpdated?: (part: any) => void;
       onQuestionAsked?: (event: QuestionAskedEvent) => void;
+      onPermissionAsked?: (event: PermissionAskedEvent) => void;
       onComplete?: () => void;
     },
     agentId?: string
@@ -476,6 +492,20 @@ export class OpenCodeService {
                 id: props.id,
                 sessionID: props.sessionID,
                 questions: props.questions,
+                tool: props.tool,
+              });
+            }
+            return;
+          }
+
+          // The server is requesting permission (tool blocking)
+          if (data.type === 'permission.asked') {
+            const props = data.properties;
+            if (props?.sessionID === sessionId) {
+              callbacks?.onPermissionAsked?.({
+                id: props.id,
+                sessionID: props.sessionID,
+                permission: props.permission,
                 tool: props.tool,
               });
             }
@@ -581,6 +611,54 @@ export class OpenCodeService {
       return response.json();
     } catch (error) {
       console.error('Error fetching pending questions:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Approve a permission request.
+   */
+  async approvePermission(requestId: string): Promise<boolean> {
+    try {
+      const response = await fetch(`${this.baseUrl}/permission/${requestId}/approve`, {
+        method: 'POST',
+        headers: this.getHeaders(),
+      });
+      return response.ok;
+    } catch (error) {
+      console.error('Error approving permission:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Deny a permission request.
+   */
+  async denyPermission(requestId: string): Promise<boolean> {
+    try {
+      const response = await fetch(`${this.baseUrl}/permission/${requestId}/deny`, {
+        method: 'POST',
+        headers: this.getHeaders(),
+      });
+      return response.ok;
+    } catch (error) {
+      console.error('Error denying permission:', error);
+      return false;
+    }
+  }
+
+  /**
+   * List all pending permission requests (for background polling/notifications).
+   */
+  async listPendingPermissions(): Promise<PermissionAskedEvent[]> {
+    try {
+      const response = await fetch(`${this.baseUrl}/permission`, {
+        headers: this.getHeaders(),
+      });
+      if (!response.ok) throw new Error('Failed to fetch pending permissions');
+      return response.json();
+    } catch (error) {
+      console.error('Error fetching pending permissions:', error);
       return [];
     }
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -102,6 +102,17 @@ export interface ChatQuestion {
   custom?: boolean;
 }
 
+export interface ChatPermission {
+  /** The requestID from the server (e.g. "perm_...") — used for approve/deny */
+  requestId: string;
+  /** The permission request description */
+  message: string;
+  /** Short header label */
+  header?: string;
+  /** Optional detailed explanation */
+  details?: string;
+}
+
 export interface ChatMessagePart {
   type: 'text' | 'tool-call' | 'reasoning';
   content?: string;


### PR DESCRIPTION
## Summary
- Removes conditional rendering of the custom text input field
- Makes the "Other" option available for all questions by default
- Updates placeholder text to "Other (type your answer)..." for clarity

## Details
Previously, the custom text input was only shown when:
- The `question.custom` flag was `true`, OR
- There were no predefined options

This PR makes the custom text input always visible, allowing users to provide custom text input for any question, regardless of whether predefined options exist.

## Changes
- Modified `src/components/chat/QuestionDisplay.tsx`:
  - Removed conditional check `(question.custom || !hasOptions)`
  - Custom text input now always renders
  - Updated placeholder text to clarify it's the "Other" option

Closes #22