### PR TITLE
feat(chat): improve agent selection and add abort button

### DIFF
--- a/src/components/chat/ChatTab.tsx
+++ b/src/components/chat/ChatTab.tsx
@@ -125,7 +125,7 @@ export default function ChatTab({ session, server }: ChatTabProps) {
   const flatListRef = useRef<FlatList>(null);
   const [service] = useState(() => new OpenCodeService(server));
 
-  const [selectedAgent, setSelectedAgent] = useState<string>('build');
+  const [selectedAgent, setSelectedAgent] = useState<string>('');
   const [showAgentPicker, setShowAgentPicker] = useState(false);
   const [agents, setAgents] = useState<Agent[]>([]);
   const [agentsLoading, setAgentsLoading] = useState(true);
@@ -159,8 +159,8 @@ export default function ChatTab({ session, server }: ChatTabProps) {
           (a) => a.mode === 'primary' && !a.hidden
         );
         setAgents(primaryAgents);
-        // Default to first primary agent if current selection isn't in the list
-        if (primaryAgents.length > 0 && !primaryAgents.find((a) => a.name === selectedAgent)) {
+        // Default to first primary agent if current selection isn't in the list or is empty
+        if (primaryAgents.length > 0 && (!selectedAgent || !primaryAgents.find((a) => a.name === selectedAgent))) {
           setSelectedAgent(primaryAgents[0].name);
         }
       } catch (error) {
@@ -306,6 +306,18 @@ export default function ChatTab({ session, server }: ChatTabProps) {
 
   const removeAttachment = (id: string) => {
     setAttachments(attachments.filter(a => a.id !== id));
+  };
+
+  const handleStop = async () => {
+    try {
+      await service.abortSession(session.id);
+      // The stream will naturally end or error out, so we rely on that to clear loading state
+      // But we can force it here for immediate UI feedback
+      setLoading(false);
+    } catch (error) {
+      console.error('Error aborting session:', error);
+      Alert.alert('Error', 'Failed to stop generation');
+    }
   };
 
   const handleSend = async () => {
@@ -748,13 +760,23 @@ keyExtractor={(item: MessageAttachment) => item.id}
             testID="chat-input"
           />
 
-          <TouchableOpacity
-            className="rounded-full px-5 py-2.5 justify-center items-center bg-primary"
-            onPress={handleSend}
-            testID="send-message-btn"
-          >
-            <Text className="text-on-primary font-semibold">Send</Text>
-          </TouchableOpacity>
+          {loading ? (
+            <TouchableOpacity
+              className="rounded-full px-5 py-2.5 justify-center items-center bg-danger"
+              onPress={handleStop}
+              testID="stop-message-btn"
+            >
+              <Text className="text-on-primary font-semibold">Stop</Text>
+            </TouchableOpacity>
+          ) : (
+            <TouchableOpacity
+              className="rounded-full px-5 py-2.5 justify-center items-center bg-primary"
+              onPress={handleSend}
+              testID="send-message-btn"
+            >
+              <Text className="text-on-primary font-semibold">Send</Text>
+            </TouchableOpacity>
+          )}
         </View>
       </View>
 

--- a/src/components/chat/ChatTab.tsx
+++ b/src/components/chat/ChatTab.tsx
@@ -154,9 +154,10 @@ export default function ChatTab({ session, server }: ChatTabProps) {
       try {
         setAgentsLoading(true);
         const fetchedAgents = await service.getAgents();
-        // Show only non-hidden primary agents in the picker
+        // Show non-hidden agents that are either primary or 'all'
+        // Some backends might return agents without a mode, so we'll be permissive if mode is missing but it's not explicitly hidden
         const primaryAgents = fetchedAgents.filter(
-          (a) => a.mode === 'primary' && !a.hidden
+          (a) => (!a.mode || a.mode === 'primary' || a.mode === 'all') && !a.hidden
         );
         setAgents(primaryAgents);
         // Default to first primary agent if current selection isn't in the list or is empty


### PR DESCRIPTION
Fixes #25 and #27

## Summary
This PR addresses two issues related to the chat interface:
1.  **Agent Selection (#25)**: The agent selector now correctly defaults to the first available primary agent if no agent is selected, ensuring that all available primary agents are selectable and the default isn't hardcoded to a potentially unavailable 'build' agent.
2.  **Abort Functionality (#27)**: Added a 'Stop' button to the chat interface that allows users to abort a running session.

## Changes
-   **src/components/chat/ChatTab.tsx**:
    -   Added `handleStop` function to call `service.abortSession`.
    -   Replaced the 'Send' button with a 'Stop' button when the chat is loading.
    -   Updated `selectedAgent` state initialization to be empty by default.
    -   Updated `useEffect` logic to select the first primary agent if the current selection is invalid or empty.

## Testing
-   Verified with `tsc` (no errors).
-   Logic for agent selection ensures valid state even if 'build' agent is missing.
-   Stop button is only visible during active requests.