### PR TITLE
feat: add model selection dropdown

### DIFF
--- a/src/components/chat/ChatTab.tsx
+++ b/src/components/chat/ChatTab.tsx
@@ -184,12 +184,20 @@ export default function ChatTab({ session, server }: ChatTabProps) {
         const data = await service.getProviders();
         if (data) {
           setProviders(data.all || []);
-          setConnectedProviders(data.connected || []);
-          setDefaultModelId(data.default);
-          
+          const connected = data.connected || [];
+          setConnectedProviders(connected);
+
+          // data.default is a Record<providerID, modelID> — resolve to a single model string
+          const defaults = data.default || {};
+          const resolvedDefault = connected.length > 0
+            ? defaults[connected[0]]
+            : Object.values(defaults)[0];
+
+          setDefaultModelId(resolvedDefault);
+
           const currentSelected = useStore.getState().selectedModels?.[session.id];
-          if (data.default && !currentSelected) {
-            useStore.getState().setSelectedModel?.(session.id, data.default);
+          if (resolvedDefault && !currentSelected) {
+            useStore.getState().setSelectedModel?.(session.id, resolvedDefault);
           }
         }
       } catch (error) {

--- a/src/components/chat/ChatTab.tsx
+++ b/src/components/chat/ChatTab.tsx
@@ -29,6 +29,8 @@ import MarkdownRenderer from './MarkdownRenderer';
 import ToolCallDisplay from './ToolCallDisplay';
 import QuestionDisplay from './QuestionDisplay';
 import PermissionDisplay from './PermissionDisplay';
+import ModelSelector from './ModelSelector';
+import { Provider } from '../../types';
 
 const StyledImage = withUniwind(Image);
 const StyledActivityIndicator = withUniwind(ActivityIndicator);
@@ -110,7 +112,7 @@ function convertApiMessageToChatMessage(apiMsg: ApiMessage): ChatMessage {
 
 export default function ChatTab({ session, server }: ChatTabProps) {
   const colors = useThemeColors();
-  const { messages, addMessage, setMessages, prependMessages, setViewedSessionId } = useStore();
+  const { messages, hasMoreMessages, addMessage, setMessages, prependMessages, setHasMoreMessages, setViewedSessionId, selectedModels, setSelectedModel } = useStore();
   const [input, setInput] = useState('');
   const [attachments, setAttachments] = useState<MessageAttachment[]>([]);
   const [loading, setLoading] = useState(false);
@@ -126,6 +128,11 @@ export default function ChatTab({ session, server }: ChatTabProps) {
   const [showAgentPicker, setShowAgentPicker] = useState(false);
   const [agents, setAgents] = useState<Agent[]>([]);
   const [agentsLoading, setAgentsLoading] = useState(true);
+
+  const [providers, setProviders] = useState<Provider[]>([]);
+  const [connectedProviders, setConnectedProviders] = useState<string[]>([]);
+  const [defaultModelId, setDefaultModelId] = useState<string | undefined>(undefined);
+  const [providersLoading, setProvidersLoading] = useState(true);
 
   // ─── Notification suppression: report which session is being viewed ───
   useFocusEffect(
@@ -169,6 +176,30 @@ export default function ChatTab({ session, server }: ChatTabProps) {
     };
     loadAgents();
   }, [service]);
+
+  useEffect(() => {
+    const loadProviders = async () => {
+      try {
+        setProvidersLoading(true);
+        const data = await service.getProviders();
+        if (data) {
+          setProviders(data.all || []);
+          setConnectedProviders(data.connected || []);
+          setDefaultModelId(data.default);
+          
+          const currentSelected = useStore.getState().selectedModels[session.id];
+          if (data.default && !currentSelected) {
+            useStore.getState().setSelectedModel(session.id, data.default);
+          }
+        }
+      } catch (error) {
+        console.error('Error loading providers:', error);
+      } finally {
+        setProvidersLoading(false);
+      }
+    };
+    loadProviders();
+  }, [service, session.id]);
 
   // Auto-scroll to bottom when keyboard opens
   useEffect(() => {
@@ -365,7 +396,8 @@ export default function ChatTab({ session, server }: ChatTabProps) {
             }
           },
         },
-        selectedAgent
+        selectedAgent,
+        selectedModels[session.id]
       );
 
       setStreamingText('');
@@ -657,23 +689,38 @@ keyExtractor={(item: MessageAttachment) => item.id}
       )}
 
       <View className="bg-surface border-t border-border">
-        {/* Agent selector row */}
-        <View className="flex-row items-center px-3 pt-2 pb-1">
-          <Text className="text-text-subtle text-xs mr-2">Agent:</Text>
-          {agentsLoading ? (
-            <ActivityIndicator size="small" color={colors.textMuted} />
-          ) : agents.length > 0 ? (
-            <TouchableOpacity
-              onPress={() => setShowAgentPicker(true)}
-              className="flex-row items-center bg-surface-elevated px-2.5 py-1 rounded-full border border-border"
-              testID="agent-selector"
-            >
-              <Text className="text-text text-xs font-medium">{agents.find(a => a.name === selectedAgent)?.name ?? selectedAgent}</Text>
-              <Text className="text-text-muted text-[10px] ml-1">▼</Text>
-            </TouchableOpacity>
-          ) : (
-            <Text className="text-text-subtle text-xs">No agents available</Text>
-          )}
+        {/* Agent and Model selector row */}
+        <View className="flex-row items-center px-3 pt-2 pb-1 justify-between z-10">
+          <View className="flex-row items-center flex-1 pr-2">
+            <Text className="text-text-subtle text-xs mr-2">Agent:</Text>
+            {agentsLoading ? (
+              <ActivityIndicator size="small" color={colors.textMuted} />
+            ) : agents.length > 0 ? (
+              <TouchableOpacity
+                onPress={() => setShowAgentPicker(true)}
+                className="flex-row items-center bg-surface-elevated px-2.5 py-1 rounded-full border border-border flex-shrink"
+                testID="agent-selector"
+              >
+                <Text className="text-text text-xs font-medium" numberOfLines={1} ellipsizeMode="tail">
+                  {agents.find(a => a.name === selectedAgent)?.name ?? selectedAgent}
+                </Text>
+                <Text className="text-text-muted text-[10px] ml-1">▼</Text>
+              </TouchableOpacity>
+            ) : (
+              <Text className="text-text-subtle text-xs">No agents available</Text>
+            )}
+          </View>
+          
+          <View className="flex-row items-center flex-1 justify-end">
+            <ModelSelector
+              providers={providers}
+              connectedProviders={connectedProviders}
+              defaultModelId={defaultModelId}
+              selectedModelId={selectedModels[session.id] || null}
+              onSelectModel={(modelId) => setSelectedModel(session.id, modelId)}
+              loading={providersLoading}
+            />
+          </View>
         </View>
 
         {/* Input row */}

--- a/src/components/chat/ChatTab.tsx
+++ b/src/components/chat/ChatTab.tsx
@@ -187,9 +187,9 @@ export default function ChatTab({ session, server }: ChatTabProps) {
           setConnectedProviders(data.connected || []);
           setDefaultModelId(data.default);
           
-          const currentSelected = useStore.getState().selectedModels[session.id];
+          const currentSelected = useStore.getState().selectedModels?.[session.id];
           if (data.default && !currentSelected) {
-            useStore.getState().setSelectedModel(session.id, data.default);
+            useStore.getState().setSelectedModel?.(session.id, data.default);
           }
         }
       } catch (error) {
@@ -397,7 +397,7 @@ export default function ChatTab({ session, server }: ChatTabProps) {
           },
         },
         selectedAgent,
-        selectedModels[session.id]
+        selectedModels?.[session.id]
       );
 
       setStreamingText('');
@@ -716,8 +716,8 @@ keyExtractor={(item: MessageAttachment) => item.id}
               providers={providers}
               connectedProviders={connectedProviders}
               defaultModelId={defaultModelId}
-              selectedModelId={selectedModels[session.id] || null}
-              onSelectModel={(modelId) => setSelectedModel(session.id, modelId)}
+              selectedModelId={selectedModels?.[session.id] || null}
+              onSelectModel={(modelId) => setSelectedModel?.(session.id, modelId)}
               loading={providersLoading}
             />
           </View>

--- a/src/components/chat/ChatTab.tsx
+++ b/src/components/chat/ChatTab.tsx
@@ -112,7 +112,7 @@ function convertApiMessageToChatMessage(apiMsg: ApiMessage): ChatMessage {
 
 export default function ChatTab({ session, server }: ChatTabProps) {
   const colors = useThemeColors();
-  const { messages, hasMoreMessages, addMessage, setMessages, prependMessages, setHasMoreMessages, setViewedSessionId, selectedModels, setSelectedModel } = useStore();
+  const { messages, addMessage, setMessages, prependMessages, setViewedSessionId, selectedModels, setSelectedModel } = useStore();
   const [input, setInput] = useState('');
   const [attachments, setAttachments] = useState<MessageAttachment[]>([]);
   const [loading, setLoading] = useState(false);

--- a/src/components/chat/ModelSelector.tsx
+++ b/src/components/chat/ModelSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import {
   View,
   Text,
@@ -33,10 +33,11 @@ export default function ModelSelector({
   const [showPicker, setShowPicker] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [expandedProviders, setExpandedProviders] = useState<Record<string, boolean>>({});
+  const hasInitialized = useRef(false);
 
   // Auto-expand connected providers initially
   useEffect(() => {
-    if (providers.length > 0 && Object.keys(expandedProviders).length === 0) {
+    if (providers.length > 0 && !hasInitialized.current) {
       const initialExpanded: Record<string, boolean> = {};
       providers.forEach(p => {
         if (connectedProviders.includes(p.id)) {
@@ -44,8 +45,9 @@ export default function ModelSelector({
         }
       });
       setExpandedProviders(initialExpanded);
+      hasInitialized.current = true;
     }
-  }, [providers, connectedProviders, expandedProviders]);
+  }, [providers, connectedProviders]);
 
   const toggleProvider = (providerId: string) => {
     setExpandedProviders(prev => ({ ...prev, [providerId]: !prev[providerId] }));

--- a/src/components/chat/ModelSelector.tsx
+++ b/src/components/chat/ModelSelector.tsx
@@ -11,6 +11,7 @@ import {
   KeyboardAvoidingView,
   Platform,
   Dimensions,
+  Keyboard,
 } from 'react-native';
 import { Provider, Model } from '../../types';
 import { useThemeColors } from '../../hooks/useThemeColors';
@@ -94,7 +95,29 @@ export default function ModelSelector({
     return selectedModelId.split('/').pop() || selectedModelId;
   }, [selectedModelId, providers]);
 
-  const maxScrollHeight = Dimensions.get('window').height * 0.5;
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+
+  useEffect(() => {
+    const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+    const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+
+    const showSub = Keyboard.addListener(showEvent, (e) => {
+      setKeyboardHeight(e.endCoordinates.height);
+    });
+    const hideSub = Keyboard.addListener(hideEvent, () => {
+      setKeyboardHeight(0);
+    });
+
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, []);
+
+  const windowHeight = Dimensions.get('window').height;
+  // Reserve space for: header (~50), search input (~50), bottom padding (~40)
+  const chromeHeight = 140;
+  const maxScrollHeight = windowHeight * 0.6 - keyboardHeight - chromeHeight;
 
   return (
     <>
@@ -125,7 +148,7 @@ export default function ModelSelector({
       >
         <KeyboardAvoidingView
           className="flex-1"
-          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+          behavior="padding"
         >
           <Pressable
             className="flex-1 bg-overlay justify-end"
@@ -149,7 +172,7 @@ export default function ModelSelector({
                   autoCapitalize="none"
                 />
 
-                <ScrollView style={{ maxHeight: maxScrollHeight }}>
+                <ScrollView style={{ maxHeight: Math.max(maxScrollHeight, 120) }} keyboardShouldPersistTaps="handled">
                   {filteredProviders.map(provider => {
                     const modelEntries = Object.values(provider.models || {});
                     if (modelEntries.length === 0) return null;

--- a/src/components/chat/ModelSelector.tsx
+++ b/src/components/chat/ModelSelector.tsx
@@ -77,7 +77,7 @@ export default function ModelSelector({
 
   // Find the display name of the selected model
   const selectedModelName = useMemo(() => {
-    if (!selectedModelId) return 'Select Model';
+    if (!selectedModelId || typeof selectedModelId !== 'string') return 'Select Model';
     for (const p of providers) {
       if (p.models && p.models[selectedModelId]) {
         return p.models[selectedModelId].name;

--- a/src/components/chat/ModelSelector.tsx
+++ b/src/components/chat/ModelSelector.tsx
@@ -8,6 +8,9 @@ import {
   ActivityIndicator,
   TextInput,
   ScrollView,
+  KeyboardAvoidingView,
+  Platform,
+  Dimensions,
 } from 'react-native';
 import { Provider, Model } from '../../types';
 import { useThemeColors } from '../../hooks/useThemeColors';
@@ -33,6 +36,7 @@ export default function ModelSelector({
   const [showPicker, setShowPicker] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [expandedProviders, setExpandedProviders] = useState<Record<string, boolean>>({});
+  const [showAllProviders, setShowAllProviders] = useState(false);
   const hasInitialized = useRef(false);
 
   // Auto-expand connected providers initially
@@ -53,11 +57,17 @@ export default function ModelSelector({
     setExpandedProviders(prev => ({ ...prev, [providerId]: !prev[providerId] }));
   };
 
+  // Only show connected providers by default; show all when searching or toggled
+  const visibleProviders = useMemo(() => {
+    if (searchQuery.trim() || showAllProviders) return providers;
+    return providers.filter(p => connectedProviders.includes(p.id));
+  }, [providers, connectedProviders, searchQuery, showAllProviders]);
+
   const filteredProviders = useMemo(() => {
-    if (!searchQuery.trim()) return providers;
+    if (!searchQuery.trim()) return visibleProviders;
     
     const query = searchQuery.toLowerCase();
-    return providers.map(provider => {
+    return visibleProviders.map(provider => {
       const modelsMap = provider.models || {};
       const filteredModels = Object.values(modelsMap).filter(
         model => (model.name || '').toLowerCase().includes(query) || (model.id || '').toLowerCase().includes(query)
@@ -73,7 +83,9 @@ export default function ModelSelector({
         }, {} as Record<string, Model>)
       };
     }).filter(p => Object.keys(p.models || {}).length > 0 || (p.name || '').toLowerCase().includes(query));
-  }, [providers, searchQuery]);
+  }, [visibleProviders, searchQuery]);
+
+  const disconnectedCount = providers.length - providers.filter(p => connectedProviders.includes(p.id)).length;
 
   // Find the display name of the selected model
   const selectedModelName = useMemo(() => {
@@ -85,6 +97,8 @@ export default function ModelSelector({
     }
     return selectedModelId.split('/').pop() || selectedModelId;
   }, [selectedModelId, providers]);
+
+  const maxScrollHeight = Dimensions.get('window').height * 0.5;
 
   return (
     <>
@@ -113,94 +127,114 @@ export default function ModelSelector({
         animationType="fade"
         onRequestClose={() => setShowPicker(false)}
       >
-        <Pressable
-          className="flex-1 bg-overlay justify-end"
-          onPress={() => setShowPicker(false)}
+        <KeyboardAvoidingView
+          className="flex-1"
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         >
-          <View className="bg-surface rounded-t-2xl p-4 pb-8 max-h-[80%]">
-            <View className="flex-row justify-between items-center mb-3">
-              <Text className="text-text font-semibold text-base">Select Model</Text>
-              <TouchableOpacity onPress={() => setShowPicker(false)}>
-                <Text className="text-text-muted text-xl">×</Text>
-              </TouchableOpacity>
-            </View>
+          <Pressable
+            className="flex-1 bg-overlay justify-end"
+            onPress={() => setShowPicker(false)}
+          >
+            <Pressable onPress={() => {/* stop propagation — prevent dismiss when tapping content */}}>
+              <View className="bg-surface rounded-t-2xl p-4 pb-8">
+                <View className="flex-row justify-between items-center mb-3">
+                  <Text className="text-text font-semibold text-base">Select Model</Text>
+                  <TouchableOpacity onPress={() => setShowPicker(false)}>
+                    <Text className="text-text-muted text-xl">×</Text>
+                  </TouchableOpacity>
+                </View>
 
-            <TextInput
-              className="border border-border rounded-lg px-3 py-2 text-text mb-4 bg-background"
-              placeholder="Search models..."
-              placeholderTextColor={colors.textSubtle}
-              value={searchQuery}
-              onChangeText={setSearchQuery}
-              autoCapitalize="none"
-            />
+                <TextInput
+                  className="border border-border rounded-lg px-3 py-2 text-text mb-4 bg-background"
+                  placeholder="Search models..."
+                  placeholderTextColor={colors.textSubtle}
+                  value={searchQuery}
+                  onChangeText={setSearchQuery}
+                  autoCapitalize="none"
+                />
 
-            <ScrollView className="flex-1">
-              {filteredProviders.map(provider => {
-                const modelEntries = Object.values(provider.models || {});
-                if (modelEntries.length === 0) return null;
-                
-                const isExpanded = expandedProviders[provider.id] || searchQuery.length > 0;
-                
-                return (
-                  <View key={provider.id} className="mb-2">
-                    <TouchableOpacity
-                      className="flex-row justify-between items-center bg-surface-elevated p-3 rounded-lg"
-                      onPress={() => toggleProvider(provider.id)}
-                    >
-                      <View className="flex-row items-center">
-                        <Text className="text-text font-medium">{provider.name}</Text>
-                        {!connectedProviders.includes(provider.id) && (
-                          <Text className="text-text-subtle text-[10px] ml-2 px-1 border border-border rounded">Not Connected</Text>
+                <ScrollView style={{ maxHeight: maxScrollHeight }}>
+                  {filteredProviders.map(provider => {
+                    const modelEntries = Object.values(provider.models || {});
+                    if (modelEntries.length === 0) return null;
+                    
+                    const isExpanded = expandedProviders[provider.id] || searchQuery.length > 0;
+                    
+                    return (
+                      <View key={provider.id} className="mb-2">
+                        <TouchableOpacity
+                          className="flex-row justify-between items-center bg-surface-elevated p-3 rounded-lg"
+                          onPress={() => toggleProvider(provider.id)}
+                        >
+                          <View className="flex-row items-center">
+                            <Text className="text-text font-medium">{provider.name}</Text>
+                            {!connectedProviders.includes(provider.id) && (
+                              <Text className="text-text-subtle text-[10px] ml-2 px-1 border border-border rounded">Not Connected</Text>
+                            )}
+                          </View>
+                          <Text className="text-text-muted">{isExpanded ? '▲' : '▼'}</Text>
+                        </TouchableOpacity>
+
+                        {isExpanded && (
+                          <View className="mt-1 ml-2">
+                            {modelEntries.map(model => {
+                              const isSelected = selectedModelId === model.id;
+                              const isDefault = defaultModelId === model.id;
+                              
+                              return (
+                                <TouchableOpacity
+                                  key={model.id}
+                                  className={`flex-row items-center justify-between p-3 rounded-lg mb-1 ${isSelected ? 'bg-primary/10 border border-primary' : 'border border-transparent'}`}
+                                  onPress={() => {
+                                    onSelectModel(model.id);
+                                    setShowPicker(false);
+                                  }}
+                                >
+                                  <View className="flex-1">
+                                    <View className="flex-row items-center">
+                                      <Text className={`text-sm font-medium ${isSelected ? 'text-primary' : 'text-text'}`}>
+                                        {model.name}
+                                      </Text>
+                                      {isDefault && (
+                                        <Text className="text-[10px] text-info ml-2 border border-info px-1 rounded">Default</Text>
+                                      )}
+                                    </View>
+                                    {model.family && (
+                                      <Text className="text-text-subtle text-xs mt-0.5">{model.family}</Text>
+                                    )}
+                                  </View>
+                                  {isSelected && (
+                                    <Text className="text-primary text-sm">✓</Text>
+                                  )}
+                                </TouchableOpacity>
+                              );
+                            })}
+                          </View>
                         )}
                       </View>
-                      <Text className="text-text-muted">{isExpanded ? '▲' : '▼'}</Text>
-                    </TouchableOpacity>
+                    );
+                  })}
+                  {filteredProviders.length === 0 && (
+                    <Text className="text-text-muted text-center py-4">No models found</Text>
+                  )}
+                </ScrollView>
 
-                    {isExpanded && (
-                      <View className="mt-1 ml-2">
-                        {modelEntries.map(model => {
-                          const isSelected = selectedModelId === model.id;
-                          const isDefault = defaultModelId === model.id;
-                          
-                          return (
-                            <TouchableOpacity
-                              key={model.id}
-                              className={`flex-row items-center justify-between p-3 rounded-lg mb-1 ${isSelected ? 'bg-primary/10 border border-primary' : 'border border-transparent'}`}
-                              onPress={() => {
-                                onSelectModel(model.id);
-                                setShowPicker(false);
-                              }}
-                            >
-                              <View className="flex-1">
-                                <View className="flex-row items-center">
-                                  <Text className={`text-sm font-medium ${isSelected ? 'text-primary' : 'text-text'}`}>
-                                    {model.name}
-                                  </Text>
-                                  {isDefault && (
-                                    <Text className="text-[10px] text-info ml-2 border border-info px-1 rounded">Default</Text>
-                                  )}
-                                </View>
-                                {model.family && (
-                                  <Text className="text-text-subtle text-xs mt-0.5">{model.family}</Text>
-                                )}
-                              </View>
-                              {isSelected && (
-                                <Text className="text-primary text-sm">✓</Text>
-                              )}
-                            </TouchableOpacity>
-                          );
-                        })}
-                      </View>
-                    )}
-                  </View>
-                );
-              })}
-              {filteredProviders.length === 0 && (
-                <Text className="text-text-muted text-center py-4">No models found</Text>
-              )}
-            </ScrollView>
-          </View>
-        </Pressable>
+                {!searchQuery.trim() && disconnectedCount > 0 && (
+                  <TouchableOpacity
+                    className="mt-3 py-2 items-center"
+                    onPress={() => setShowAllProviders(prev => !prev)}
+                  >
+                    <Text className="text-primary text-xs">
+                      {showAllProviders
+                        ? 'Show connected only'
+                        : `Show all providers (+${disconnectedCount} disconnected)`}
+                    </Text>
+                  </TouchableOpacity>
+                )}
+              </View>
+            </Pressable>
+          </Pressable>
+        </KeyboardAvoidingView>
       </Modal>
     </>
   );

--- a/src/components/chat/ModelSelector.tsx
+++ b/src/components/chat/ModelSelector.tsx
@@ -56,25 +56,28 @@ export default function ModelSelector({
     
     const query = searchQuery.toLowerCase();
     return providers.map(provider => {
-      const filteredModels = Object.values(provider.models).filter(
-        model => model.name.toLowerCase().includes(query) || model.id.toLowerCase().includes(query)
+      const modelsMap = provider.models || {};
+      const filteredModels = Object.values(modelsMap).filter(
+        model => (model.name || '').toLowerCase().includes(query) || (model.id || '').toLowerCase().includes(query)
       );
       
       return {
         ...provider,
         models: filteredModels.reduce((acc, model) => {
-          acc[model.id] = model;
+          if (model.id) {
+            acc[model.id] = model;
+          }
           return acc;
         }, {} as Record<string, Model>)
       };
-    }).filter(p => Object.keys(p.models).length > 0 || p.name.toLowerCase().includes(query));
+    }).filter(p => Object.keys(p.models || {}).length > 0 || (p.name || '').toLowerCase().includes(query));
   }, [providers, searchQuery]);
 
   // Find the display name of the selected model
   const selectedModelName = useMemo(() => {
     if (!selectedModelId) return 'Select Model';
     for (const p of providers) {
-      if (p.models[selectedModelId]) {
+      if (p.models && p.models[selectedModelId]) {
         return p.models[selectedModelId].name;
       }
     }
@@ -131,7 +134,7 @@ export default function ModelSelector({
 
             <ScrollView className="flex-1">
               {filteredProviders.map(provider => {
-                const modelEntries = Object.values(provider.models);
+                const modelEntries = Object.values(provider.models || {});
                 if (modelEntries.length === 0) return null;
                 
                 const isExpanded = expandedProviders[provider.id] || searchQuery.length > 0;

--- a/src/components/chat/ModelSelector.tsx
+++ b/src/components/chat/ModelSelector.tsx
@@ -1,0 +1,202 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  Modal,
+  Pressable,
+  ActivityIndicator,
+  TextInput,
+  ScrollView,
+} from 'react-native';
+import { Provider, Model } from '../../types';
+import { useThemeColors } from '../../hooks/useThemeColors';
+
+interface ModelSelectorProps {
+  providers: Provider[];
+  connectedProviders: string[];
+  defaultModelId?: string;
+  selectedModelId: string | null;
+  onSelectModel: (modelId: string) => void;
+  loading?: boolean;
+}
+
+export default function ModelSelector({
+  providers,
+  connectedProviders,
+  defaultModelId,
+  selectedModelId,
+  onSelectModel,
+  loading = false,
+}: ModelSelectorProps) {
+  const colors = useThemeColors();
+  const [showPicker, setShowPicker] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [expandedProviders, setExpandedProviders] = useState<Record<string, boolean>>({});
+
+  // Auto-expand connected providers initially
+  useEffect(() => {
+    if (providers.length > 0 && Object.keys(expandedProviders).length === 0) {
+      const initialExpanded: Record<string, boolean> = {};
+      providers.forEach(p => {
+        if (connectedProviders.includes(p.id)) {
+          initialExpanded[p.id] = true;
+        }
+      });
+      setExpandedProviders(initialExpanded);
+    }
+  }, [providers, connectedProviders, expandedProviders]);
+
+  const toggleProvider = (providerId: string) => {
+    setExpandedProviders(prev => ({ ...prev, [providerId]: !prev[providerId] }));
+  };
+
+  const filteredProviders = useMemo(() => {
+    if (!searchQuery.trim()) return providers;
+    
+    const query = searchQuery.toLowerCase();
+    return providers.map(provider => {
+      const filteredModels = Object.values(provider.models).filter(
+        model => model.name.toLowerCase().includes(query) || model.id.toLowerCase().includes(query)
+      );
+      
+      return {
+        ...provider,
+        models: filteredModels.reduce((acc, model) => {
+          acc[model.id] = model;
+          return acc;
+        }, {} as Record<string, Model>)
+      };
+    }).filter(p => Object.keys(p.models).length > 0 || p.name.toLowerCase().includes(query));
+  }, [providers, searchQuery]);
+
+  // Find the display name of the selected model
+  const selectedModelName = useMemo(() => {
+    if (!selectedModelId) return 'Select Model';
+    for (const p of providers) {
+      if (p.models[selectedModelId]) {
+        return p.models[selectedModelId].name;
+      }
+    }
+    return selectedModelId.split('/').pop() || selectedModelId;
+  }, [selectedModelId, providers]);
+
+  return (
+    <>
+      <View className="flex-row items-center px-3 pt-2 pb-1">
+        <Text className="text-text-subtle text-xs mr-2">Model:</Text>
+        {loading ? (
+          <ActivityIndicator size="small" color={colors.textMuted} />
+        ) : providers.length > 0 ? (
+          <TouchableOpacity
+            onPress={() => setShowPicker(true)}
+            className="flex-row items-center bg-surface-elevated px-2.5 py-1 rounded-full border border-border flex-shrink"
+          >
+            <Text className="text-text text-xs font-medium" numberOfLines={1} ellipsizeMode="tail">
+              {selectedModelName}
+            </Text>
+            <Text className="text-text-muted text-[10px] ml-1">▼</Text>
+          </TouchableOpacity>
+        ) : (
+          <Text className="text-text-subtle text-xs">No models available</Text>
+        )}
+      </View>
+
+      <Modal
+        visible={showPicker}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setShowPicker(false)}
+      >
+        <Pressable
+          className="flex-1 bg-overlay justify-end"
+          onPress={() => setShowPicker(false)}
+        >
+          <View className="bg-surface rounded-t-2xl p-4 pb-8 max-h-[80%]">
+            <View className="flex-row justify-between items-center mb-3">
+              <Text className="text-text font-semibold text-base">Select Model</Text>
+              <TouchableOpacity onPress={() => setShowPicker(false)}>
+                <Text className="text-text-muted text-xl">×</Text>
+              </TouchableOpacity>
+            </View>
+
+            <TextInput
+              className="border border-border rounded-lg px-3 py-2 text-text mb-4 bg-background"
+              placeholder="Search models..."
+              placeholderTextColor={colors.textSubtle}
+              value={searchQuery}
+              onChangeText={setSearchQuery}
+              autoCapitalize="none"
+            />
+
+            <ScrollView className="flex-1">
+              {filteredProviders.map(provider => {
+                const modelEntries = Object.values(provider.models);
+                if (modelEntries.length === 0) return null;
+                
+                const isExpanded = expandedProviders[provider.id] || searchQuery.length > 0;
+                
+                return (
+                  <View key={provider.id} className="mb-2">
+                    <TouchableOpacity
+                      className="flex-row justify-between items-center bg-surface-elevated p-3 rounded-lg"
+                      onPress={() => toggleProvider(provider.id)}
+                    >
+                      <View className="flex-row items-center">
+                        <Text className="text-text font-medium">{provider.name}</Text>
+                        {!connectedProviders.includes(provider.id) && (
+                          <Text className="text-text-subtle text-[10px] ml-2 px-1 border border-border rounded">Not Connected</Text>
+                        )}
+                      </View>
+                      <Text className="text-text-muted">{isExpanded ? '▲' : '▼'}</Text>
+                    </TouchableOpacity>
+
+                    {isExpanded && (
+                      <View className="mt-1 ml-2">
+                        {modelEntries.map(model => {
+                          const isSelected = selectedModelId === model.id;
+                          const isDefault = defaultModelId === model.id;
+                          
+                          return (
+                            <TouchableOpacity
+                              key={model.id}
+                              className={`flex-row items-center justify-between p-3 rounded-lg mb-1 ${isSelected ? 'bg-primary/10 border border-primary' : 'border border-transparent'}`}
+                              onPress={() => {
+                                onSelectModel(model.id);
+                                setShowPicker(false);
+                              }}
+                            >
+                              <View className="flex-1">
+                                <View className="flex-row items-center">
+                                  <Text className={`text-sm font-medium ${isSelected ? 'text-primary' : 'text-text'}`}>
+                                    {model.name}
+                                  </Text>
+                                  {isDefault && (
+                                    <Text className="text-[10px] text-info ml-2 border border-info px-1 rounded">Default</Text>
+                                  )}
+                                </View>
+                                {model.family && (
+                                  <Text className="text-text-subtle text-xs mt-0.5">{model.family}</Text>
+                                )}
+                              </View>
+                              {isSelected && (
+                                <Text className="text-primary text-sm">✓</Text>
+                              )}
+                            </TouchableOpacity>
+                          );
+                        })}
+                      </View>
+                    )}
+                  </View>
+                );
+              })}
+              {filteredProviders.length === 0 && (
+                <Text className="text-text-muted text-center py-4">No models found</Text>
+              )}
+            </ScrollView>
+          </View>
+        </Pressable>
+      </Modal>
+    </>
+  );
+}

--- a/src/components/chat/ModelSelector.tsx
+++ b/src/components/chat/ModelSelector.tsx
@@ -36,7 +36,6 @@ export default function ModelSelector({
   const [showPicker, setShowPicker] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [expandedProviders, setExpandedProviders] = useState<Record<string, boolean>>({});
-  const [showAllProviders, setShowAllProviders] = useState(false);
   const hasInitialized = useRef(false);
 
   // Auto-expand connected providers initially
@@ -57,17 +56,16 @@ export default function ModelSelector({
     setExpandedProviders(prev => ({ ...prev, [providerId]: !prev[providerId] }));
   };
 
-  // Only show connected providers by default; show all when searching or toggled
-  const visibleProviders = useMemo(() => {
-    if (searchQuery.trim() || showAllProviders) return providers;
+  // Only show providers that have auth configured (i.e. are connected)
+  const connectedProviderList = useMemo(() => {
     return providers.filter(p => connectedProviders.includes(p.id));
-  }, [providers, connectedProviders, searchQuery, showAllProviders]);
+  }, [providers, connectedProviders]);
 
   const filteredProviders = useMemo(() => {
-    if (!searchQuery.trim()) return visibleProviders;
+    if (!searchQuery.trim()) return connectedProviderList;
     
     const query = searchQuery.toLowerCase();
-    return visibleProviders.map(provider => {
+    return connectedProviderList.map(provider => {
       const modelsMap = provider.models || {};
       const filteredModels = Object.values(modelsMap).filter(
         model => (model.name || '').toLowerCase().includes(query) || (model.id || '').toLowerCase().includes(query)
@@ -83,9 +81,7 @@ export default function ModelSelector({
         }, {} as Record<string, Model>)
       };
     }).filter(p => Object.keys(p.models || {}).length > 0 || (p.name || '').toLowerCase().includes(query));
-  }, [visibleProviders, searchQuery]);
-
-  const disconnectedCount = providers.length - providers.filter(p => connectedProviders.includes(p.id)).length;
+  }, [connectedProviderList, searchQuery]);
 
   // Find the display name of the selected model
   const selectedModelName = useMemo(() => {
@@ -166,12 +162,7 @@ export default function ModelSelector({
                           className="flex-row justify-between items-center bg-surface-elevated p-3 rounded-lg"
                           onPress={() => toggleProvider(provider.id)}
                         >
-                          <View className="flex-row items-center">
-                            <Text className="text-text font-medium">{provider.name}</Text>
-                            {!connectedProviders.includes(provider.id) && (
-                              <Text className="text-text-subtle text-[10px] ml-2 px-1 border border-border rounded">Not Connected</Text>
-                            )}
-                          </View>
+                      <Text className="text-text font-medium">{provider.name}</Text>
                           <Text className="text-text-muted">{isExpanded ? '▲' : '▼'}</Text>
                         </TouchableOpacity>
 
@@ -219,18 +210,7 @@ export default function ModelSelector({
                   )}
                 </ScrollView>
 
-                {!searchQuery.trim() && disconnectedCount > 0 && (
-                  <TouchableOpacity
-                    className="mt-3 py-2 items-center"
-                    onPress={() => setShowAllProviders(prev => !prev)}
-                  >
-                    <Text className="text-primary text-xs">
-                      {showAllProviders
-                        ? 'Show connected only'
-                        : `Show all providers (+${disconnectedCount} disconnected)`}
-                    </Text>
-                  </TouchableOpacity>
-                )}
+
               </View>
             </Pressable>
           </Pressable>

--- a/src/services/opencode.ts
+++ b/src/services/opencode.ts
@@ -1,4 +1,4 @@
-import { Server, Session, GitFile, Project, FileNode, Agent } from '../types';
+import { Server, Session, GitFile, Project, FileNode, Agent, ProvidersResponse } from '../types';
 import EventSource from 'react-native-sse';
 import base64 from 'base-64';
 
@@ -245,6 +245,19 @@ export class OpenCodeService {
     }
   }
 
+  async getProviders(): Promise<ProvidersResponse | null> {
+    try {
+      const response = await fetch(`${this.baseUrl}/provider`, {
+        headers: this.getHeaders(),
+      });
+      if (!response.ok) throw new Error('Failed to fetch providers');
+      return response.json();
+    } catch (error) {
+      console.error('Error fetching providers:', error);
+      return null;
+    }
+  }
+
   async createSession(title: string, directory?: string): Promise<Session | null> {
     try {
       const params = new URLSearchParams();
@@ -427,7 +440,8 @@ export class OpenCodeService {
       onPermissionAsked?: (event: PermissionAskedEvent) => void;
       onComplete?: () => void;
     },
-    agentId?: string
+    agentId?: string,
+    modelId?: string
   ): Promise<void> {
     // Prepare message parts
     const parts: MessagePart[] = [
@@ -475,6 +489,9 @@ export class OpenCodeService {
             const asyncBody: Record<string, any> = { parts };
             if (agentId) {
               asyncBody.agentID = agentId;
+            }
+            if (modelId) {
+              asyncBody.modelID = modelId;
             }
             fetch(`${this.baseUrl}/session/${sessionId}/prompt_async`, {
               method: 'POST',

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -57,6 +57,10 @@ interface AppState {
   addFileAnnotation: (sessionId: string, annotation: FileAnnotation) => void;
   removeFileAnnotation: (sessionId: string, filePath: string) => void;
   clearFileAnnotations: (sessionId: string) => void;
+
+  // Models
+  selectedModels: Record<string, string>;
+  setSelectedModel: (sessionId: string, modelId: string) => void;
 }
 
 const SERVERS_KEY = '@opencode_servers';
@@ -267,5 +271,12 @@ export const useStore = create<AppState>((set, get) => ({
     const fileAnnotations = { ...get().fileAnnotations };
     delete fileAnnotations[sessionId];
     set({ fileAnnotations });
+  },
+
+  // Models
+  selectedModels: {},
+  setSelectedModel: (sessionId: string, modelId: string) => {
+    const selectedModels = { ...get().selectedModels, [sessionId]: modelId };
+    set({ selectedModels });
   },
 }));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -163,6 +163,26 @@ export interface Agent {
   native?: boolean;
 }
 
+export interface Model {
+  id: string;
+  providerID: string;
+  name: string;
+  family?: string;
+  status?: string;
+}
+
+export interface Provider {
+  id: string;
+  name: string;
+  models: Record<string, Model>;
+}
+
+export interface ProvidersResponse {
+  all: Provider[];
+  connected: string[];
+  default: string;
+}
+
 export interface TerminalState {
   history: string[];
   currentInput: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -180,7 +180,7 @@ export interface Provider {
 export interface ProvidersResponse {
   all: Provider[];
   connected: string[];
-  default: string;
+  default: Record<string, string>;
 }
 
 export interface TerminalState {


### PR DESCRIPTION
Closes #30

## Summary
- Added `ModelSelector` component with accordion layout grouping models by provider
- Added live fuzzy search for filtering models and providers
- Integrated `getProviders` API call in `OpenCodeService` to fetch models from server
- Persisted selected model per session in Zustand store
- Automatically falls back to the server's default configured model when none is explicitly selected for the session