### PR TITLE
fix chat stream and permission lifecycle

### DIFF
--- a/src/__tests__/opencode-chat-api.test.ts
+++ b/src/__tests__/opencode-chat-api.test.ts
@@ -1,0 +1,456 @@
+/**
+ * Chat-focused OpenCode API integration tests.
+ *
+ * These tests run against a live OpenCode server and create sessions inside a
+ * temporary directory under the current repository. The directory is removed
+ * after the suite completes, even on failure.
+ *
+ * Usage: npx tsx src/__tests__/opencode-chat-api.test.ts [base-url]
+ * Default base URL: http://localhost:4096
+ * Optional auth: OPENCODE_API_KEY=... npx tsx ...
+ */
+
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+const BASE_URL = process.argv[2] || 'http://localhost:4096';
+const API_KEY = process.env.OPENCODE_API_KEY;
+const REPO_ROOT = process.cwd();
+const TEMP_PARENT_DIR = path.join(REPO_ROOT, '.tmp');
+
+interface TestResult {
+  name: string;
+  passed: boolean;
+  error?: string;
+}
+
+interface SessionRecord {
+  id: string;
+  title: string;
+  directory?: string;
+}
+
+interface SseEvent {
+  type: string;
+  properties?: Record<string, any>;
+}
+
+interface WaitForStreamOptions {
+  sessionId: string;
+  prompt: string;
+  timeoutMs?: number;
+  stopWhen: (event: SseEvent, events: SseEvent[]) => boolean;
+}
+
+const results: TestResult[] = [];
+const createdSessionIds = new Set<string>();
+
+let tempDir = '';
+let cleanupStarted = false;
+
+function authHeaders(): Record<string, string> {
+  if (!API_KEY) return {};
+  const credentials = Buffer.from(`opencode:${API_KEY}`).toString('base64');
+  return { Authorization: `Basic ${credentials}` };
+}
+
+async function requestJson(url: string, init?: RequestInit) {
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeaders(),
+      ...(init?.headers || {}),
+    },
+  });
+
+  return response;
+}
+
+async function test(name: string, fn: () => Promise<void>) {
+  try {
+    await fn();
+    results.push({ name, passed: true });
+    console.log(`  ✓ ${name}`);
+  } catch (err: any) {
+    results.push({ name, passed: false, error: err?.message || String(err) });
+    console.log(`  ✗ ${name}`);
+    console.log(`    ${err?.message || String(err)}`);
+  }
+}
+
+async function testWithRetries(name: string, retries: number, fn: (attempt: number) => Promise<void>) {
+  await test(name, async () => {
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= retries + 1; attempt += 1) {
+      try {
+        if (attempt > 1) {
+          console.log(`    retry ${attempt - 1}/${retries}`);
+        }
+        await fn(attempt);
+        return;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    throw lastError;
+  });
+}
+
+function assert(condition: boolean, message: string) {
+  if (!condition) throw new Error(message);
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function summarizeRelevantEvent(event: SseEvent) {
+  if (event.type === 'message.part.updated') {
+    const part = event.properties?.part;
+    return {
+      type: event.type,
+      sessionID: part?.sessionID,
+      messageID: part?.messageID,
+      role: part?.role,
+      partType: part?.type,
+      delta: event.properties?.delta,
+      part,
+    };
+  }
+
+  return {
+    type: event.type,
+    properties: event.properties,
+  };
+}
+
+function logJson(label: string, value: unknown) {
+  console.log(`    ${label}: ${JSON.stringify(value, null, 2)}`);
+}
+
+async function createTempTestDir() {
+  await mkdir(TEMP_PARENT_DIR, { recursive: true });
+  tempDir = path.join(
+    TEMP_PARENT_DIR,
+    `opencode-chat-api-${Date.now()}-${crypto.randomBytes(4).toString('hex')}`,
+  );
+  await mkdir(tempDir, { recursive: true });
+  await writeFile(
+    path.join(tempDir, 'README.txt'),
+    'Temporary workspace for OpenCode chat integration tests. Safe to delete.\n',
+    'utf8',
+  );
+  console.log(`Temporary test directory: ${tempDir}`);
+}
+
+async function cleanup() {
+  if (cleanupStarted) return;
+  cleanupStarted = true;
+
+  for (const sessionId of createdSessionIds) {
+    try {
+      await requestJson(`${BASE_URL}/session/${sessionId}`, {
+        method: 'DELETE',
+      });
+    } catch (error) {
+      console.log(`    cleanup warning: failed to delete session ${sessionId}: ${String(error)}`);
+    }
+  }
+
+  if (tempDir) {
+    try {
+      await rm(tempDir, { recursive: true, force: true });
+    } catch (error) {
+      console.log(`    cleanup warning: failed to remove temp dir ${tempDir}: ${String(error)}`);
+    }
+  }
+}
+
+async function createSession(title: string): Promise<SessionRecord> {
+  const response = await requestJson(
+    `${BASE_URL}/session?directory=${encodeURIComponent(tempDir)}`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ title }),
+    },
+  );
+
+  assert(response.ok, `Failed to create session: ${response.status}`);
+  const session = (await response.json()) as SessionRecord;
+  createdSessionIds.add(session.id);
+  return session;
+}
+
+async function getMessages(sessionId: string) {
+  const response = await requestJson(`${BASE_URL}/session/${sessionId}/message`);
+  assert(response.ok, `Failed to fetch messages for ${sessionId}: ${response.status}`);
+  return response.json();
+}
+
+async function listPendingQuestions() {
+  const response = await requestJson(`${BASE_URL}/question`);
+  assert(response.ok, `Failed to fetch pending questions: ${response.status}`);
+  return response.json();
+}
+
+async function listPendingPermissions() {
+  const response = await requestJson(`${BASE_URL}/permission`);
+  assert(response.ok, `Failed to fetch pending permissions: ${response.status}`);
+  return response.json();
+}
+
+async function replyToQuestion(requestId: string, answers: string[][]) {
+  const response = await requestJson(`${BASE_URL}/question/${requestId}/reply`, {
+    method: 'POST',
+    body: JSON.stringify({ answers }),
+  });
+  assert(response.ok, `Failed to reply to question ${requestId}: ${response.status}`);
+}
+
+async function denyPermission(requestId: string) {
+  const response = await requestJson(`${BASE_URL}/permission/${requestId}/deny`, {
+    method: 'POST',
+  });
+  assert(response.ok, `Failed to deny permission ${requestId}: ${response.status}`);
+}
+
+async function waitForCondition<T>(
+  label: string,
+  fn: () => Promise<T>,
+  predicate: (value: T) => boolean,
+  timeoutMs = 15000,
+  intervalMs = 500,
+): Promise<T> {
+  const started = Date.now();
+
+  while (Date.now() - started < timeoutMs) {
+    const value = await fn();
+    if (predicate(value)) {
+      return value;
+    }
+    await delay(intervalMs);
+  }
+
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
+async function waitForStream({ sessionId, prompt, timeoutMs = 90000, stopWhen }: WaitForStreamOptions) {
+  const controller = new AbortController();
+  const response = await requestJson(`${BASE_URL}/event`, {
+    headers: authHeaders(),
+    signal: controller.signal,
+  });
+
+  assert(response.ok, `Failed to connect to SSE stream: ${response.status}`);
+  if (!response.body) {
+    throw new Error('SSE response did not include a body');
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const events: SseEvent[] = [];
+
+  let timedOut = false;
+  let prompted = false;
+  let buffer = '';
+
+  const timeoutId = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+
+      let boundary = buffer.indexOf('\n\n');
+      while (boundary >= 0) {
+        const rawEvent = buffer.slice(0, boundary);
+        buffer = buffer.slice(boundary + 2);
+        boundary = buffer.indexOf('\n\n');
+
+        const dataLines = rawEvent
+          .split(/\r?\n/)
+          .filter((line) => line.startsWith('data:'))
+          .map((line) => line.slice(5).trimStart());
+
+        if (dataLines.length === 0) {
+          continue;
+        }
+
+        const event = JSON.parse(dataLines.join('\n')) as SseEvent;
+
+        if (event.type === 'server.connected' && !prompted) {
+          prompted = true;
+          const promptResponse = await requestJson(`${BASE_URL}/session/${sessionId}/prompt_async`, {
+            method: 'POST',
+            body: JSON.stringify({
+              parts: [{ type: 'text', text: prompt }],
+            }),
+          });
+          assert(promptResponse.ok, `Failed to send prompt_async: ${promptResponse.status}`);
+          continue;
+        }
+
+        const isRelevant =
+          event.properties?.sessionID === sessionId ||
+          event.properties?.part?.sessionID === sessionId;
+
+        if (!isRelevant) {
+          continue;
+        }
+
+        events.push(event);
+        if (stopWhen(event, events)) {
+          return events;
+        }
+      }
+    }
+
+    throw new Error('SSE stream ended before the expected event was observed');
+  } catch (error) {
+    if (timedOut) {
+      const sample = events.slice(-5).map(summarizeRelevantEvent);
+      throw new Error(`Timed out waiting for expected SSE event. Recent events: ${JSON.stringify(sample, null, 2)}`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+    controller.abort();
+    reader.releaseLock();
+  }
+}
+
+async function run() {
+  console.log(`\nRunning OpenCode chat API integration tests against ${BASE_URL}\n`);
+
+  await createTempTestDir();
+
+  process.once('SIGINT', () => {
+    cleanup().finally(() => process.exit(130));
+  });
+  process.once('SIGTERM', () => {
+    cleanup().finally(() => process.exit(143));
+  });
+
+  try {
+    await test('creates a session inside the temp test directory', async () => {
+      const session = await createSession('chat-api-temp-dir-check');
+      assert(session.directory === tempDir, `Expected session directory ${tempDir}, got ${session.directory}`);
+    });
+
+    await test('captures assistant streaming events and final message parts', async () => {
+      const session = await createSession('chat-api-streaming');
+      const events = await waitForStream({
+        sessionId: session.id,
+        prompt: 'Reply with exactly two short lines: first line "alpha", second line "beta".',
+        stopWhen: (event) => event.type === 'session.status' && event.properties?.status?.type === 'idle',
+      });
+
+      const partUpdates = events.filter((event) => event.type === 'message.part.updated');
+      assert(partUpdates.length > 0, 'Expected at least one message.part.updated event');
+
+      logJson('sample message.part.updated event', summarizeRelevantEvent(partUpdates[0]));
+
+      const messages = await getMessages(session.id);
+      const assistantMessage = [...messages].reverse().find((message: any) => message.info?.role === 'assistant');
+      assert(!!assistantMessage, 'Expected a final assistant message');
+      assert(Array.isArray(assistantMessage.parts), 'Expected final assistant message to include parts');
+
+      logJson('final assistant message parts', assistantMessage.parts);
+    });
+
+    await testWithRetries('captures a structured question payload and clears it after reply', 3, async (attempt) => {
+      const session = await createSession(`chat-api-question-attempt-${attempt}`);
+      const events = await waitForStream({
+        sessionId: session.id,
+        prompt: 'Use the question tool to ask me one structured question with exactly two answer options. Do not answer it yourself.',
+        stopWhen: (event) => event.type === 'question.asked',
+      });
+
+      const questionEvent = events.find((event) => event.type === 'question.asked');
+      if (!questionEvent) {
+        throw new Error('Expected a question.asked event');
+      }
+      const questionProps = questionEvent.properties || {};
+      logJson('question.asked payload', summarizeRelevantEvent(questionEvent));
+
+      const pendingQuestions = await listPendingQuestions();
+      const pendingQuestion = pendingQuestions.find((item: any) => item.id === questionProps.id);
+      assert(!!pendingQuestion, 'Expected pending question to appear in GET /question');
+      logJson('GET /question item', pendingQuestion);
+
+      const answers = (questionProps.questions || []).map((question: any) => {
+        const firstOption = question.options?.[0]?.label;
+        return [firstOption || 'test answer'];
+      });
+      assert(answers.length > 0, 'Expected question payload to include at least one question');
+
+      await replyToQuestion(questionProps.id, answers);
+      await waitForCondition(
+        `question ${questionProps.id} to clear`,
+        listPendingQuestions,
+        (items) => !items.some((item: any) => item.id === questionProps.id),
+      );
+    });
+
+    await testWithRetries('captures a permission payload and clears it after deny', 3, async (attempt) => {
+      const session = await createSession(`chat-api-permission-attempt-${attempt}`);
+      const events = await waitForStream({
+        sessionId: session.id,
+        prompt: 'Use the read tool to read ~/.zshrc. If permission is required, request permission and stop immediately without answering.',
+        stopWhen: (event) => event.type === 'permission.asked',
+      });
+
+      const permissionEvent = events.find((event) => event.type === 'permission.asked');
+      if (!permissionEvent) {
+        throw new Error('Expected a permission.asked event');
+      }
+      const permissionProps = permissionEvent.properties || {};
+      logJson('permission.asked payload', summarizeRelevantEvent(permissionEvent));
+
+      const pendingPermissions = await listPendingPermissions();
+      const pendingPermission = pendingPermissions.find((item: any) => item.id === permissionProps.id);
+      assert(!!pendingPermission, 'Expected pending permission to appear in GET /permission');
+      logJson('GET /permission item', pendingPermission);
+
+      await denyPermission(permissionProps.id);
+      await waitForCondition(
+        `permission ${permissionProps.id} to clear`,
+        listPendingPermissions,
+        (items) => !items.some((item: any) => item.id === permissionProps.id),
+      );
+    });
+  } finally {
+    await cleanup();
+  }
+
+  console.log('\n' + '='.repeat(60));
+  const passed = results.filter((r) => r.passed).length;
+  const failed = results.filter((r) => !r.passed).length;
+  console.log(`Results: ${passed} passed, ${failed} failed, ${results.length} total`);
+
+  if (failed > 0) {
+    console.log('\nFailed tests:');
+    for (const result of results.filter((r) => !r.passed)) {
+      console.log(`  ✗ ${result.name}: ${result.error}`);
+    }
+    process.exit(1);
+  }
+
+  console.log('\nAll tests passed!');
+  process.exit(0);
+}
+
+run().catch(async (error) => {
+  await cleanup();
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/src/__tests__/opencode-chat-api.test.ts
+++ b/src/__tests__/opencode-chat-api.test.ts
@@ -31,6 +31,13 @@ interface SessionRecord {
   directory?: string;
 }
 
+interface SessionCreateOptions {
+  model?: {
+    providerID: string;
+    modelID: string;
+  };
+}
+
 interface SseEvent {
   type: string;
   properties?: Record<string, any>;
@@ -45,6 +52,10 @@ interface WaitForStreamOptions {
 
 const results: TestResult[] = [];
 const createdSessionIds = new Set<string>();
+const TEST_MODEL = {
+  providerID: 'openai',
+  modelID: 'gpt-5.4',
+} as const;
 
 let tempDir = '';
 let cleanupStarted = false;
@@ -170,12 +181,15 @@ async function cleanup() {
   }
 }
 
-async function createSession(title: string): Promise<SessionRecord> {
+async function createSession(title: string, options?: SessionCreateOptions): Promise<SessionRecord> {
   const response = await requestJson(
     `${BASE_URL}/session?directory=${encodeURIComponent(tempDir)}`,
     {
       method: 'POST',
-      body: JSON.stringify({ title }),
+      body: JSON.stringify({
+        title,
+        ...(options?.model ? { model: options.model } : {}),
+      }),
     },
   );
 
@@ -342,15 +356,15 @@ async function run() {
 
   try {
     await test('creates a session inside the temp test directory', async () => {
-      const session = await createSession('chat-api-temp-dir-check');
+      const session = await createSession('chat-api-temp-dir-check', { model: TEST_MODEL });
       assert(session.directory === tempDir, `Expected session directory ${tempDir}, got ${session.directory}`);
     });
 
     await test('captures assistant streaming events and final message parts', async () => {
-      const session = await createSession('chat-api-streaming');
+      const session = await createSession('chat-api-streaming', { model: TEST_MODEL });
       const events = await waitForStream({
         sessionId: session.id,
-        prompt: 'Reply with exactly two short lines: first line "alpha", second line "beta".',
+        prompt: 'Is Atal Bihari Vajpayee the 10th Prime Minister of India, and if so, what is his fourth most important achievement? Explain your ranking briefly before answering.',
         stopWhen: (event) => event.type === 'session.status' && event.properties?.status?.type === 'idle',
       });
 
@@ -358,6 +372,26 @@ async function run() {
       assert(partUpdates.length > 0, 'Expected at least one message.part.updated event');
 
       logJson('sample message.part.updated event', summarizeRelevantEvent(partUpdates[0]));
+      const reasoningEvents = events.filter((event) => {
+        const partType = event.properties?.part?.type;
+        return event.type === 'message.part.updated' && partType === 'reasoning';
+      });
+      if (reasoningEvents.length > 0) {
+        logJson('sample reasoning event', summarizeRelevantEvent(reasoningEvents[0]));
+      }
+      const streamedReasoningEvents = reasoningEvents.filter((event) => {
+        const text = event.properties?.part?.text;
+        return typeof text === 'string' && text.trim().length > 0;
+      });
+      logJson(
+        'reasoning stream summary',
+        {
+          totalReasoningEvents: reasoningEvents.length,
+          nonEmptyReasoningEvents: streamedReasoningEvents.length,
+          sampleNonEmptyReasoningEvent:
+            streamedReasoningEvents.length > 0 ? summarizeRelevantEvent(streamedReasoningEvents[0]) : null,
+        },
+      );
 
       const messages = await getMessages(session.id);
       const assistantMessage = [...messages].reverse().find((message: any) => message.info?.role === 'assistant');
@@ -365,10 +399,19 @@ async function run() {
       assert(Array.isArray(assistantMessage.parts), 'Expected final assistant message to include parts');
 
       logJson('final assistant message parts', assistantMessage.parts);
+      const finalReasoningParts = assistantMessage.parts.filter((part: any) => part.type === 'reasoning');
+      logJson(
+        'final reasoning summary',
+        finalReasoningParts.map((part: any) => ({
+          textLength: typeof part.text === 'string' ? part.text.length : 0,
+          hasEncryptedContent: !!part.metadata?.openai?.reasoningEncryptedContent,
+          textPreview: typeof part.text === 'string' ? part.text.slice(0, 200) : '',
+        })),
+      );
     });
 
     await testWithRetries('captures a structured question payload and clears it after reply', 3, async (attempt) => {
-      const session = await createSession(`chat-api-question-attempt-${attempt}`);
+      const session = await createSession(`chat-api-question-attempt-${attempt}`, { model: TEST_MODEL });
       const events = await waitForStream({
         sessionId: session.id,
         prompt: 'Use the question tool to ask me one structured question with exactly two answer options. Do not answer it yourself.',
@@ -402,7 +445,7 @@ async function run() {
     });
 
     await testWithRetries('captures a permission payload and clears it after deny', 3, async (attempt) => {
-      const session = await createSession(`chat-api-permission-attempt-${attempt}`);
+      const session = await createSession(`chat-api-permission-attempt-${attempt}`, { model: TEST_MODEL });
       const events = await waitForStream({
         sessionId: session.id,
         prompt: 'Use the read tool to read ~/.zshrc. If permission is required, request permission and stop immediately without answering.',

--- a/src/__tests__/opencode-chat-api.test.ts
+++ b/src/__tests__/opencode-chat-api.test.ts
@@ -47,6 +47,7 @@ interface WaitForStreamOptions {
   sessionId: string;
   prompt: string;
   timeoutMs?: number;
+  onEvent?: (event: SseEvent, events: SseEvent[]) => Promise<void> | void;
   stopWhen: (event: SseEvent, events: SseEvent[]) => boolean;
 }
 
@@ -225,11 +226,12 @@ async function replyToQuestion(requestId: string, answers: string[][]) {
   assert(response.ok, `Failed to reply to question ${requestId}: ${response.status}`);
 }
 
-async function denyPermission(requestId: string) {
-  const response = await requestJson(`${BASE_URL}/permission/${requestId}/deny`, {
+async function replyToPermission(requestId: string, reply: 'once' | 'always' | 'reject', message?: string) {
+  const response = await requestJson(`${BASE_URL}/permission/${requestId}/reply`, {
     method: 'POST',
+    body: JSON.stringify({ reply, ...(message ? { message } : {}) }),
   });
-  assert(response.ok, `Failed to deny permission ${requestId}: ${response.status}`);
+  assert(response.ok, `Failed to reply to permission ${requestId}: ${response.status}`);
 }
 
 async function waitForCondition<T>(
@@ -252,7 +254,7 @@ async function waitForCondition<T>(
   throw new Error(`Timed out waiting for ${label}`);
 }
 
-async function waitForStream({ sessionId, prompt, timeoutMs = 90000, stopWhen }: WaitForStreamOptions) {
+async function waitForStream({ sessionId, prompt, timeoutMs = 90000, onEvent, stopWhen }: WaitForStreamOptions) {
   const controller = new AbortController();
   const response = await requestJson(`${BASE_URL}/event`, {
     headers: authHeaders(),
@@ -322,6 +324,9 @@ async function waitForStream({ sessionId, prompt, timeoutMs = 90000, stopWhen }:
         }
 
         events.push(event);
+        if (onEvent) {
+          await onEvent(event, events);
+        }
         if (stopWhen(event, events)) {
           return events;
         }
@@ -444,12 +449,26 @@ async function run() {
       );
     });
 
-    await testWithRetries('captures a permission payload and clears it after deny', 3, async (attempt) => {
+    await testWithRetries('captures a permission payload and clears it after v2 reply', 3, async (attempt) => {
       const session = await createSession(`chat-api-permission-attempt-${attempt}`, { model: TEST_MODEL });
+      let replied = false;
+      let pendingPermissionSnapshot: any | null = null;
       const events = await waitForStream({
         sessionId: session.id,
         prompt: 'Use the read tool to read ~/.zshrc. If permission is required, request permission and stop immediately without answering.',
-        stopWhen: (event) => event.type === 'permission.asked',
+        onEvent: async (event) => {
+          if (event.type !== 'permission.asked' || replied) {
+            return;
+          }
+
+          const permissionProps = event.properties || {};
+          const pendingPermissions = await listPendingPermissions();
+          pendingPermissionSnapshot = pendingPermissions.find((item: any) => item.id === permissionProps.id) ?? null;
+          assert(!!pendingPermissionSnapshot, 'Expected pending permission to appear in GET /permission before reply');
+          replied = true;
+          await replyToPermission(permissionProps.id, 'reject', 'Rejected by integration test');
+        },
+        stopWhen: (event) => event.type === 'permission.replied',
       });
 
       const permissionEvent = events.find((event) => event.type === 'permission.asked');
@@ -458,13 +477,17 @@ async function run() {
       }
       const permissionProps = permissionEvent.properties || {};
       logJson('permission.asked payload', summarizeRelevantEvent(permissionEvent));
+      assert(!!pendingPermissionSnapshot, 'Expected pending permission snapshot before reply');
+      logJson('GET /permission item', pendingPermissionSnapshot);
 
-      const pendingPermissions = await listPendingPermissions();
-      const pendingPermission = pendingPermissions.find((item: any) => item.id === permissionProps.id);
-      assert(!!pendingPermission, 'Expected pending permission to appear in GET /permission');
-      logJson('GET /permission item', pendingPermission);
+      const permissionRepliedEvent = events.find(
+        (event) => event.type === 'permission.replied' && event.properties?.requestID === permissionProps.id,
+      );
+      if (!permissionRepliedEvent) {
+        throw new Error('Expected a permission.replied event for the replied permission');
+      }
+      logJson('permission.replied payload', summarizeRelevantEvent(permissionRepliedEvent));
 
-      await denyPermission(permissionProps.id);
       await waitForCondition(
         `permission ${permissionProps.id} to clear`,
         listPendingPermissions,

--- a/src/components/chat/ChatTab.tsx
+++ b/src/components/chat/ChatTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   View,
   Text,
@@ -8,12 +8,10 @@ import {
   Image,
   ActivityIndicator,
   Alert,
-  RefreshControl,
   Modal,
   Pressable,
   KeyboardAvoidingView,
   Platform,
-  Keyboard,
 } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import { withUniwind } from 'uniwind';
@@ -21,7 +19,7 @@ import * as DocumentPicker from 'expo-document-picker';
 import * as ImagePicker from 'expo-image-picker';
 import * as FileSystem from 'expo-file-system/legacy';
 import { useStore } from '../../store';
-import { Agent, ChatMessage, ChatMessagePart, ChatPermission, ChatQuestion, MessageAttachment, Server, Session } from '../../types';
+import { Agent, ChatMessage, ChatMessagePart, MessageAttachment, Server, Session } from '../../types';
 import { OpenCodeService, Message as ApiMessage, ToolMetadata, QuestionAskedEvent, PermissionAskedEvent } from '../../services/opencode';
 import { useThemeColors } from '../../hooks/useThemeColors';
 import { useAppStateRefresh } from '../../hooks/useAppStateRefresh';
@@ -37,6 +35,12 @@ interface ChatTabProps {
   session: Session;
   server: Server;
 }
+
+type ChatListItem =
+  | { kind: 'message'; key: string; message: ChatMessage }
+  | { kind: 'streaming'; key: string; content: string }
+  | { kind: 'question'; key: string; event: QuestionAskedEvent }
+  | { kind: 'permission'; key: string; event: PermissionAskedEvent };
 
 function convertApiMessageToChatMessage(apiMsg: ApiMessage): ChatMessage {
   const chatParts: ChatMessagePart[] = [];
@@ -110,7 +114,7 @@ function convertApiMessageToChatMessage(apiMsg: ApiMessage): ChatMessage {
 
 export default function ChatTab({ session, server }: ChatTabProps) {
   const colors = useThemeColors();
-  const { messages, addMessage, setMessages, prependMessages, setViewedSessionId } = useStore();
+  const { messages, addMessage, setMessages, setViewedSessionId } = useStore();
   const [input, setInput] = useState('');
   const [attachments, setAttachments] = useState<MessageAttachment[]>([]);
   const [loading, setLoading] = useState(false);
@@ -118,8 +122,6 @@ export default function ChatTab({ session, server }: ChatTabProps) {
   const [streamingText, setStreamingText] = useState('');
   const [pendingQuestion, setPendingQuestion] = useState<QuestionAskedEvent | null>(null);
   const [pendingPermission, setPendingPermission] = useState<PermissionAskedEvent | null>(null);
-  const flatListRef = useRef<FlatList>(null);
-  const lastMessageIdRef = useRef<string | null>(null);
   const [service] = useState(() => new OpenCodeService(server));
 
   const [selectedAgent, setSelectedAgent] = useState<string>('');
@@ -170,17 +172,6 @@ export default function ChatTab({ session, server }: ChatTabProps) {
     loadAgents();
   }, [service]);
 
-  // Auto-scroll to bottom when keyboard opens
-  useEffect(() => {
-    const event = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
-    const sub = Keyboard.addListener(event, () => {
-      setTimeout(() => {
-        flatListRef.current?.scrollToEnd({ animated: true });
-      }, 100);
-    });
-    return () => sub.remove();
-  }, []);
-
   const sessionMessages = messages[session.id] || [];
 
   const loadInitialMessages = useCallback(async () => {
@@ -201,17 +192,41 @@ export default function ChatTab({ session, server }: ChatTabProps) {
     loadInitialMessages();
   }, [loadInitialMessages]);
 
-  useEffect(() => {
-    if (sessionMessages.length > 0 && !initialLoading) {
-      const currentLastMessage = sessionMessages[sessionMessages.length - 1];
-      if (currentLastMessage.id !== lastMessageIdRef.current) {
-        lastMessageIdRef.current = currentLastMessage.id;
-        setTimeout(() => {
-          flatListRef.current?.scrollToEnd({ animated: true });
-        }, 100);
-      }
+  const listItems = useMemo<ChatListItem[]>(() => {
+    const items: ChatListItem[] = [];
+
+    if (pendingPermission) {
+      items.push({
+        kind: 'permission',
+        key: `pending-permission-${pendingPermission.id}`,
+        event: pendingPermission,
+      });
     }
-  }, [sessionMessages.length, initialLoading]);
+
+    if (pendingQuestion) {
+      items.push({
+        kind: 'question',
+        key: `pending-question-${pendingQuestion.id}`,
+        event: pendingQuestion,
+      });
+    }
+
+    if (streamingText) {
+      items.push({
+        kind: 'streaming',
+        key: `streaming-${session.id}`,
+        content: streamingText,
+      });
+    }
+
+    return [
+      ...items,
+      ...sessionMessages
+        .slice()
+        .reverse()
+        .map((message) => ({ kind: 'message', key: message.id, message }) satisfies ChatListItem),
+    ];
+  }, [pendingPermission, pendingQuestion, session.id, sessionMessages, streamingText]);
 
   const handlePickFile = async () => {
     try {
@@ -246,7 +261,7 @@ export default function ChatTab({ session, server }: ChatTabProps) {
   const handlePickImage = async () => {
     try {
       const permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
-      
+
       if (!permissionResult.granted) {
         Alert.alert('Permission Required', 'Please grant permission to access photos');
         return;
@@ -316,7 +331,7 @@ export default function ChatTab({ session, server }: ChatTabProps) {
       const preparedAttachments = await Promise.all(
         currentAttachments.map(async (att) => {
           let content = '';
-          
+
           if (att.type === 'image') {
             content = await FileSystem.readAsStringAsync(att.uri, {
               encoding: FileSystem.EncodingType.Base64,
@@ -472,7 +487,7 @@ export default function ChatTab({ session, server }: ChatTabProps) {
                 return <ToolCallDisplay key={part.toolCall.toolCallId || idx} toolCall={part.toolCall} />;
               }
               return null;
-            
+
             case 'reasoning':
               return (
                 <View key={idx} className="border-l-2 border-info pl-2 mb-2 opacity-70">
@@ -491,13 +506,13 @@ export default function ChatTab({ session, server }: ChatTabProps) {
     );
   };
 
-  const renderMessage = ({ item }: { item: ChatMessage }): React.ReactElement => {
-    const isUser = item.role === 'user';
+  const renderMessage = (message: ChatMessage): React.ReactElement => {
+    const isUser = message.role === 'user';
 
     return (
       <View
         className={`rounded-xl mb-3 ${isUser ? 'self-end max-w-[80%]' : 'self-start w-full'}`}
-        testID={`message-${item.role}-${item.id}`}
+        testID={`message-${message.role}-${message.id}`}
       >
         {/* User messages get the bubble style */}
         {isUser ? (
@@ -505,12 +520,12 @@ export default function ChatTab({ session, server }: ChatTabProps) {
             <View className="flex-row justify-between mb-1">
               <Text className="text-on-primary font-semibold text-xs">You</Text>
               <Text className="text-on-primary/70 text-[10px]">
-                {new Date(item.timestamp).toLocaleTimeString()}
+                {new Date(message.timestamp).toLocaleTimeString()}
               </Text>
             </View>
-            {item.attachments && item.attachments.length > 0 && (
+            {message.attachments && message.attachments.length > 0 && (
               <View className="mb-2">
-                {item.attachments.map((att) => (
+                {message.attachments.map((att) => (
                   <View key={att.id} className="mb-2">
                     {att.type === 'image' ? (
                       <StyledImage source={{ uri: att.uri }} className="w-48 h-48 rounded-lg" />
@@ -523,7 +538,7 @@ export default function ChatTab({ session, server }: ChatTabProps) {
                 ))}
               </View>
             )}
-            {renderMessageContent(item)}
+            {renderMessageContent(message)}
           </View>
         ) : (
           /* Assistant messages: full-width, no bubble, parts render inline */
@@ -531,12 +546,12 @@ export default function ChatTab({ session, server }: ChatTabProps) {
             <View className="flex-row justify-between mb-1 px-1">
               <Text className="text-text-muted font-semibold text-xs">Assistant</Text>
               <Text className="text-text-subtle text-[10px]">
-                {new Date(item.timestamp).toLocaleTimeString()}
+                {new Date(message.timestamp).toLocaleTimeString()}
               </Text>
             </View>
-            {item.attachments && item.attachments.length > 0 && (
+            {message.attachments && message.attachments.length > 0 && (
               <View className="mb-2">
-                {item.attachments.map((att) => (
+                {message.attachments.map((att) => (
                   <View key={att.id} className="mb-2">
                     {att.type === 'image' ? (
                       <StyledImage source={{ uri: att.uri }} className="w-48 h-48 rounded-lg" />
@@ -549,11 +564,62 @@ export default function ChatTab({ session, server }: ChatTabProps) {
                 ))}
               </View>
             )}
-            {renderMessageContent(item)}
+            {renderMessageContent(message)}
           </View>
         )}
       </View>
     );
+  };
+
+  const renderListItem = ({ item }: { item: ChatListItem }): React.ReactElement => {
+    switch (item.kind) {
+      case 'message':
+        return renderMessage(item.message);
+      case 'streaming':
+        return (
+          <View className="self-start w-full py-2 mb-3" testID="streaming-message">
+            <Text className="text-text-muted font-semibold text-xs mb-1 px-1">Assistant</Text>
+            <MarkdownRenderer content={item.content} />
+            {!pendingQuestion && !pendingPermission && <StyledActivityIndicator className="mt-2" />}
+          </View>
+        );
+      case 'question':
+        return (
+          <View className="mb-3">
+            {item.event.questions.map((question, idx) => (
+              <QuestionDisplay
+                key={`${item.event.id}-${idx}`}
+                question={{
+                  requestId: item.event.id,
+                  question: question.question,
+                  header: question.header,
+                  options: question.options,
+                  multiple: question.multiple,
+                  custom: question.custom,
+                }}
+                onAnswer={(selectedLabels: string[]) => {
+                  handleAnswerQuestion(item.event.id, [selectedLabels]);
+                }}
+              />
+            ))}
+          </View>
+        );
+      case 'permission':
+        return (
+          <View className="mb-3">
+            <PermissionDisplay
+              permission={{
+                requestId: item.event.id,
+                message: item.event.permission.message,
+                header: item.event.permission.header,
+                details: item.event.permission.details,
+              }}
+              onApprove={() => handleApprovePermission(item.event.id)}
+              onDeny={() => handleDenyPermission(item.event.id)}
+            />
+          </View>
+        );
+    }
   };
 
   const renderAttachment = ({ item }: { item: MessageAttachment }): React.ReactElement => (
@@ -586,62 +652,17 @@ export default function ChatTab({ session, server }: ChatTabProps) {
       testID="chat-tab"
     >
       <FlatList
-        ref={flatListRef}
-        data={sessionMessages}
-        renderItem={renderMessage}
-        keyExtractor={(item: ChatMessage) => item.id}
+        data={listItems}
+        renderItem={renderListItem}
+        keyExtractor={(item: ChatListItem) => item.key}
+        inverted
         contentContainerClassName="p-4"
         testID="messages-list"
-        maintainVisibleContentPosition={{ minIndexForVisible: 0 }}
         ListEmptyComponent={
           <View className="items-center justify-center pt-16" testID="empty-messages">
             <Text className="text-lg font-semibold text-text-muted mb-2">No messages yet</Text>
             <Text className="text-sm text-text-subtle">Start a conversation with OpenCode</Text>
           </View>
-        }
-        ListFooterComponent={
-          streamingText || pendingQuestion || pendingPermission ? (
-            <View>
-              {streamingText ? (
-                <View className="self-start w-full py-2" testID="streaming-message">
-                  <Text className="text-text-muted font-semibold text-xs mb-1 px-1">Assistant</Text>
-                  <MarkdownRenderer content={streamingText} />
-                  {!pendingQuestion && !pendingPermission && <StyledActivityIndicator className="mt-2" />}
-                </View>
-              ) : null}
-              {pendingQuestion && pendingQuestion.questions.map((q, idx) => (
-                <QuestionDisplay
-                  key={`${pendingQuestion.id}-${idx}`}
-                  question={{
-                    requestId: pendingQuestion.id,
-                    question: q.question,
-                    header: q.header,
-                    options: q.options,
-                    multiple: q.multiple,
-                    custom: q.custom,
-                  }}
-                  onAnswer={(selectedLabels: string[]) => {
-                    // Build the answers array: one entry per question
-                    // For now we only support single-question events
-                    handleAnswerQuestion(pendingQuestion.id, [selectedLabels]);
-                  }}
-                />
-              ))}
-              {pendingPermission && (
-                <PermissionDisplay
-                  key={pendingPermission.id}
-                  permission={{
-                    requestId: pendingPermission.id,
-                    message: pendingPermission.permission.message,
-                    header: pendingPermission.permission.header,
-                    details: pendingPermission.permission.details,
-                  }}
-                  onApprove={() => handleApprovePermission(pendingPermission.id)}
-                  onDeny={() => handleDenyPermission(pendingPermission.id)}
-                />
-              )}
-            </View>
-          ) : null
         }
       />
 
@@ -650,7 +671,7 @@ export default function ChatTab({ session, server }: ChatTabProps) {
           horizontal
           data={attachments}
           renderItem={renderAttachment}
-keyExtractor={(item: MessageAttachment) => item.id}
+          keyExtractor={(item: MessageAttachment) => item.id}
           contentContainerClassName="px-4 py-2 bg-surface border-t border-border"
           testID="attachments-list"
         />
@@ -678,15 +699,15 @@ keyExtractor={(item: MessageAttachment) => item.id}
 
         {/* Input row */}
         <View className="flex-row items-end px-3 pb-3 pt-1">
-          <TouchableOpacity 
+          <TouchableOpacity
             className="p-2 mr-1"
             onPress={handlePickFile}
             testID="attach-file-button"
           >
             <Text className="text-xl">📎</Text>
           </TouchableOpacity>
-          
-          <TouchableOpacity 
+
+          <TouchableOpacity
             className="p-2 mr-1"
             onPress={handlePickImage}
             testID="attach-image-button"

--- a/src/components/chat/ChatTab.tsx
+++ b/src/components/chat/ChatTab.tsx
@@ -24,6 +24,7 @@ import {
   OpenCodeService,
   Message as ApiMessage,
   MessagePart as ApiMessagePart,
+  StreamPartEvent,
   ToolMetadata,
   QuestionAskedEvent,
   PermissionAskedEvent,
@@ -67,6 +68,10 @@ function createStreamingMessage(sessionId: string): ChatMessage {
   };
 }
 
+function isTransientStreamingMessage(message: ChatMessage): boolean {
+  return message.id.startsWith('streaming-');
+}
+
 function isUserPromptEcho(part: ApiMessagePart & { sessionID?: string }, delta: string | undefined, promptText: string): boolean {
   return part.type === 'text' && !delta && part.text === promptText;
 }
@@ -105,8 +110,7 @@ function formatPermissionMessage(event: PermissionAskedEvent): { message: string
 function applyStreamUpdate(
   current: ChatMessage | null,
   sessionId: string,
-  part: ApiMessagePart & { sessionID?: string },
-  delta?: string,
+  event: StreamPartEvent,
 ): ChatMessage {
   const next = current
     ? { ...current, parts: current.parts ? [...current.parts] : [] }
@@ -114,24 +118,83 @@ function applyStreamUpdate(
 
   const parts = next.parts || [];
 
-  if (part.type === 'text' || part.type === 'reasoning') {
+  const upsertPart = (candidate: ChatMessagePart, predicate: (part: ChatMessagePart) => boolean) => {
+    const existingIndex = parts.findIndex(predicate);
+    if (existingIndex >= 0) {
+      parts[existingIndex] = { ...parts[existingIndex], ...candidate };
+      return parts[existingIndex];
+    }
+    parts.push(candidate);
+    return candidate;
+  };
+
+  if (event.type === 'message.part.delta') {
+    if (event.field !== 'text') {
+      return next;
+    }
+
+    const existingIndex = parts.findIndex((part) => part.id === event.partID);
+    if (existingIndex >= 0) {
+      const existing = parts[existingIndex];
+      parts[existingIndex] = {
+        ...existing,
+        content: `${existing.content || ''}${event.delta}`,
+      };
+    } else {
+      parts.push({
+        id: event.partID,
+        type: 'text',
+        content: event.delta,
+      });
+    }
+
+    next.parts = parts;
+    next.content = buildPlainContent(parts);
+    return next;
+  }
+
+  const { part, delta } = event;
+
+  if (part.type === 'reasoning') {
+    const reasoningContent = typeof part.text === 'string' ? part.text : delta || '';
+    const previous = parts.find((item) => item.id === part.id);
+    const nextContent =
+      typeof part.text === 'string' && part.text.length > 0
+        ? part.text
+        : `${previous?.content || ''}${delta || ''}`;
+
+    upsertPart(
+      {
+        id: part.id,
+        type: 'reasoning',
+        content: nextContent,
+      },
+      (item) => item.id === part.id,
+    );
+
+    next.parts = parts;
+    next.content = buildPlainContent(parts);
+    return next;
+  }
+
+  if (part.type === 'text') {
     const content = typeof part.text === 'string' ? part.text : delta || '';
     if (!content) {
       return next;
     }
 
-    const lastPart = parts[parts.length - 1];
-    if (lastPart?.type === part.type) {
-      parts[parts.length - 1] = {
+    const previous = parts.find((item) => item.id === part.id);
+    upsertPart(
+      {
+        id: part.id,
         type: part.type,
         content:
           typeof part.text === 'string'
             ? part.text
-            : `${lastPart.content || ''}${delta || ''}`,
-      };
-    } else {
-      parts.push({ type: part.type, content });
-    }
+            : `${previous?.content || ''}${delta || ''}`,
+      },
+      (item) => item.id === part.id,
+    );
 
     next.parts = parts;
     next.content = buildPlainContent(parts);
@@ -141,6 +204,7 @@ function applyStreamUpdate(
   if (part.type === 'tool-invocation') {
     const invocation = part.toolInvocation;
     const toolCall: ChatMessagePart = {
+      id: part.id,
       type: 'tool-call',
       toolCall: {
         toolCallId: invocation.toolCallId,
@@ -152,7 +216,7 @@ function applyStreamUpdate(
     };
 
     const existingIndex = parts.findIndex(
-      (item) => item.type === 'tool-call' && item.toolCall?.toolCallId === invocation.toolCallId,
+      (item) => item.id === part.id || (item.type === 'tool-call' && item.toolCall?.toolCallId === invocation.toolCallId),
     );
 
     if (existingIndex >= 0) {
@@ -178,16 +242,17 @@ function convertApiMessageToChatMessage(apiMsg: ApiMessage): ChatMessage {
   for (const part of apiMsg.parts) {
     switch (part.type) {
       case 'text':
-        chatParts.push({ type: 'text', content: part.text });
+        chatParts.push({ id: part.id, type: 'text', content: part.text });
         plainContent += part.text;
         break;
       case 'reasoning':
-        chatParts.push({ type: 'reasoning', content: part.text });
+        chatParts.push({ id: part.id, type: 'reasoning', content: part.text });
         break;
       case 'tool-invocation': {
         const inv = part.toolInvocation;
         const meta: ToolMetadata | undefined = toolMeta[inv.toolCallId];
         chatParts.push({
+          id: part.id,
           type: 'tool-call',
           toolCall: {
             toolCallId: inv.toolCallId,
@@ -546,11 +611,11 @@ export default function ChatTab({ session, server }: ChatTabProps) {
         messageText,
         preparedAttachments.length > 0 ? preparedAttachments : undefined,
         {
-          onPartUpdated: (part, delta) => {
-            if (!streamingMessage && isUserPromptEcho(part, delta, messageText)) {
+          onPartUpdated: (event) => {
+            if (event.type === 'message.part.updated' && !streamingMessage && isUserPromptEcho(event.part, event.delta, messageText)) {
               return;
             }
-            setStreamingMessage((current) => applyStreamUpdate(current, session.id, part, delta));
+            setStreamingMessage((current) => applyStreamUpdate(current, session.id, event));
             setBlockedPlaceholder(null);
           },
           onQuestionAsked: async (event) => {
@@ -654,6 +719,7 @@ export default function ChatTab({ session, server }: ChatTabProps) {
 
   const renderMessageContent = (item: ChatMessage) => {
     const isUser = item.role === 'user';
+    const isTransient = isTransientStreamingMessage(item);
     const parts = item.parts;
 
     // If no parts, fall back to plain content rendered as markdown
@@ -686,7 +752,15 @@ export default function ChatTab({ session, server }: ChatTabProps) {
 
             case 'reasoning':
               if (!part.content?.trim()) {
-                return null;
+                if (!isTransient) {
+                  return null;
+                }
+                return (
+                  <View key={idx} className="border-l-2 border-info pl-2 mb-2 opacity-70">
+                    <Text className="text-text-muted text-[10px] font-semibold mb-0.5">Thinking</Text>
+                    <Text className="text-text-muted text-[13px] italic leading-4">Thinking...</Text>
+                  </View>
+                );
               }
               return (
                 <View key={idx} className="border-l-2 border-info pl-2 mb-2 opacity-70">

--- a/src/components/chat/ChatTab.tsx
+++ b/src/components/chat/ChatTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import {
   View,
   Text,
@@ -20,7 +20,14 @@ import * as ImagePicker from 'expo-image-picker';
 import * as FileSystem from 'expo-file-system/legacy';
 import { useStore } from '../../store';
 import { Agent, ChatMessage, ChatMessagePart, MessageAttachment, Server, Session } from '../../types';
-import { OpenCodeService, Message as ApiMessage, ToolMetadata, QuestionAskedEvent, PermissionAskedEvent } from '../../services/opencode';
+import {
+  OpenCodeService,
+  Message as ApiMessage,
+  MessagePart as ApiMessagePart,
+  ToolMetadata,
+  QuestionAskedEvent,
+  PermissionAskedEvent,
+} from '../../services/opencode';
 import { useThemeColors } from '../../hooks/useThemeColors';
 import { useAppStateRefresh } from '../../hooks/useAppStateRefresh';
 import MarkdownRenderer from './MarkdownRenderer';
@@ -38,9 +45,128 @@ interface ChatTabProps {
 
 type ChatListItem =
   | { kind: 'message'; key: string; message: ChatMessage }
-  | { kind: 'streaming'; key: string; content: string }
+  | { kind: 'streaming'; key: string; message: ChatMessage }
+  | { kind: 'blocked-placeholder'; key: string; promptType: 'question' | 'permission' }
   | { kind: 'question'; key: string; event: QuestionAskedEvent }
   | { kind: 'permission'; key: string; event: PermissionAskedEvent };
+
+function buildPlainContent(parts: ChatMessagePart[]): string {
+  return parts
+    .filter((part) => part.type === 'text')
+    .map((part) => part.content || '')
+    .join('');
+}
+
+function createStreamingMessage(sessionId: string): ChatMessage {
+  return {
+    id: `streaming-${sessionId}`,
+    role: 'assistant',
+    content: '',
+    parts: [],
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function isUserPromptEcho(part: ApiMessagePart & { sessionID?: string }, delta: string | undefined, promptText: string): boolean {
+  return part.type === 'text' && !delta && part.text === promptText;
+}
+
+function formatPermissionMessage(event: PermissionAskedEvent): { message: string; details?: string; patterns?: string[] } {
+  const permissionType = event.permission.type || 'unknown';
+  const filepath = typeof event.permission.metadata?.filepath === 'string'
+    ? event.permission.metadata.filepath
+    : undefined;
+  const parentDir = typeof event.permission.metadata?.parentDir === 'string'
+    ? event.permission.metadata.parentDir
+    : undefined;
+
+  switch (permissionType) {
+    case 'external_directory':
+      return {
+        message: filepath
+          ? `OpenCode wants to access ${filepath}.`
+          : 'OpenCode wants to access a directory outside the workspace.',
+        details: parentDir
+          ? `Parent directory: ${parentDir}`
+          : 'This request requires access outside the current workspace.',
+        patterns: event.permission.patterns,
+      };
+    default:
+      return {
+        message: filepath
+          ? `OpenCode requested ${permissionType.replace(/_/g, ' ')} for ${filepath}.`
+          : `OpenCode requested ${permissionType.replace(/_/g, ' ')}.`,
+        details: parentDir,
+        patterns: event.permission.patterns,
+      };
+  }
+}
+
+function applyStreamUpdate(
+  current: ChatMessage | null,
+  sessionId: string,
+  part: ApiMessagePart & { sessionID?: string },
+  delta?: string,
+): ChatMessage {
+  const next = current
+    ? { ...current, parts: current.parts ? [...current.parts] : [] }
+    : createStreamingMessage(sessionId);
+
+  const parts = next.parts || [];
+
+  if (part.type === 'text' || part.type === 'reasoning') {
+    const content = typeof part.text === 'string' ? part.text : delta || '';
+    if (!content) {
+      return next;
+    }
+
+    const lastPart = parts[parts.length - 1];
+    if (lastPart?.type === part.type) {
+      parts[parts.length - 1] = {
+        type: part.type,
+        content:
+          typeof part.text === 'string'
+            ? part.text
+            : `${lastPart.content || ''}${delta || ''}`,
+      };
+    } else {
+      parts.push({ type: part.type, content });
+    }
+
+    next.parts = parts;
+    next.content = buildPlainContent(parts);
+    return next;
+  }
+
+  if (part.type === 'tool-invocation') {
+    const invocation = part.toolInvocation;
+    const toolCall: ChatMessagePart = {
+      type: 'tool-call',
+      toolCall: {
+        toolCallId: invocation.toolCallId,
+        toolName: invocation.toolName,
+        args: invocation.args,
+        state: invocation.state,
+        result: invocation.state === 'result' ? invocation.result : undefined,
+      },
+    };
+
+    const existingIndex = parts.findIndex(
+      (item) => item.type === 'tool-call' && item.toolCall?.toolCallId === invocation.toolCallId,
+    );
+
+    if (existingIndex >= 0) {
+      parts[existingIndex] = toolCall;
+    } else {
+      parts.push(toolCall);
+    }
+
+    next.parts = parts;
+    next.content = buildPlainContent(parts);
+  }
+
+  return next;
+}
 
 function convertApiMessageToChatMessage(apiMsg: ApiMessage): ChatMessage {
   const chatParts: ChatMessagePart[] = [];
@@ -119,9 +245,11 @@ export default function ChatTab({ session, server }: ChatTabProps) {
   const [attachments, setAttachments] = useState<MessageAttachment[]>([]);
   const [loading, setLoading] = useState(false);
   const [initialLoading, setInitialLoading] = useState(true);
-  const [streamingText, setStreamingText] = useState('');
+  const [streamingMessage, setStreamingMessage] = useState<ChatMessage | null>(null);
   const [pendingQuestion, setPendingQuestion] = useState<QuestionAskedEvent | null>(null);
   const [pendingPermission, setPendingPermission] = useState<PermissionAskedEvent | null>(null);
+  const [blockedPlaceholder, setBlockedPlaceholder] = useState<'question' | 'permission' | null>(null);
+  const resolvedPermissionIdsRef = useRef<Set<string>>(new Set());
   const [service] = useState(() => new OpenCodeService(server));
 
   const [selectedAgent, setSelectedAgent] = useState<string>('');
@@ -136,17 +264,6 @@ export default function ChatTab({ session, server }: ChatTabProps) {
       return () => setViewedSessionId(null);
     }, [session.id, setViewedSessionId]),
   );
-
-  // ─── Refetch messages when app resumes from background ───
-  useAppStateRefresh(useCallback(async () => {
-    try {
-      const apiMessages = await service.getMessages(session.id);
-      const chatMessages = apiMessages.map(convertApiMessageToChatMessage);
-      setMessages(session.id, chatMessages);
-    } catch (err) {
-      console.error('Error refreshing messages on resume:', err);
-    }
-  }, [session.id, service, setMessages]));
 
   useEffect(() => {
     const loadAgents = async () => {
@@ -174,26 +291,95 @@ export default function ChatTab({ session, server }: ChatTabProps) {
 
   const sessionMessages = messages[session.id] || [];
 
-  const loadInitialMessages = useCallback(async () => {
+  const syncSessionState = useCallback(async (
+    options?: {
+      showLoader?: boolean;
+      fallbackQuestion?: QuestionAskedEvent | null;
+      fallbackPermission?: PermissionAskedEvent | null;
+      clearStreaming?: boolean;
+    },
+  ) => {
+    const {
+      showLoader = false,
+      fallbackQuestion = null,
+      fallbackPermission = null,
+      clearStreaming = false,
+    } = options || {};
+
     try {
-      setInitialLoading(true);
-      const apiMessages = await service.getMessages(session.id);
+      if (showLoader) {
+        setInitialLoading(true);
+      }
+
+      const [apiMessages, questions, permissions] = await Promise.all([
+        service.getMessages(session.id),
+        service.listPendingQuestions(),
+        service.listPendingPermissions(),
+      ]);
       const chatMessages = apiMessages.map(convertApiMessageToChatMessage);
+      const nextQuestion = questions.find((question) => question.sessionID === session.id) ?? fallbackQuestion;
+      const serverPermissionIds = new Set(permissions.map((permission) => permission.id));
+      for (const resolvedId of Array.from(resolvedPermissionIdsRef.current)) {
+        if (!serverPermissionIds.has(resolvedId)) {
+          resolvedPermissionIdsRef.current.delete(resolvedId);
+        }
+      }
+      const nextPermission = permissions.find(
+        (permission) => permission.sessionID === session.id && !resolvedPermissionIdsRef.current.has(permission.id),
+      ) ?? (fallbackPermission && !resolvedPermissionIdsRef.current.has(fallbackPermission.id) ? fallbackPermission : null);
+
       setMessages(session.id, chatMessages);
+      setPendingQuestion(nextQuestion ?? null);
+      setPendingPermission(nextPermission ?? null);
+      setBlockedPlaceholder(null);
+
+      if (clearStreaming) {
+        setStreamingMessage(null);
+      }
     } catch (error) {
-      console.error('Error loading initial messages:', error);
-      Alert.alert('Error', 'Failed to load messages from server');
+      console.error('Error syncing session state:', error);
+
+      if (fallbackQuestion) {
+        setPendingQuestion(fallbackQuestion);
+        setPendingPermission(null);
+        setBlockedPlaceholder(null);
+      }
+
+      if (fallbackPermission) {
+        setPendingPermission(fallbackPermission);
+        setPendingQuestion(null);
+        setBlockedPlaceholder(null);
+      }
+
+      if (showLoader) {
+        Alert.alert('Error', 'Failed to load messages from server');
+      }
     } finally {
-      setInitialLoading(false);
+      if (showLoader) {
+        setInitialLoading(false);
+      }
     }
   }, [session.id, service, setMessages]);
 
+  // ─── Refetch messages and pending prompts when app resumes ───
+  useAppStateRefresh(useCallback(async () => {
+    await syncSessionState();
+  }, [syncSessionState]));
+
   useEffect(() => {
-    loadInitialMessages();
-  }, [loadInitialMessages]);
+    syncSessionState({ showLoader: true, clearStreaming: true });
+  }, [syncSessionState]);
 
   const listItems = useMemo<ChatListItem[]>(() => {
     const items: ChatListItem[] = [];
+
+    if (blockedPlaceholder && !pendingQuestion && !pendingPermission) {
+      items.push({
+        kind: 'blocked-placeholder',
+        key: `blocked-placeholder-${blockedPlaceholder}-${session.id}`,
+        promptType: blockedPlaceholder,
+      });
+    }
 
     if (pendingPermission) {
       items.push({
@@ -211,11 +397,11 @@ export default function ChatTab({ session, server }: ChatTabProps) {
       });
     }
 
-    if (streamingText) {
+    if (streamingMessage) {
       items.push({
         kind: 'streaming',
         key: `streaming-${session.id}`,
-        content: streamingText,
+        message: streamingMessage,
       });
     }
 
@@ -226,7 +412,7 @@ export default function ChatTab({ session, server }: ChatTabProps) {
         .reverse()
         .map((message) => ({ kind: 'message', key: message.id, message }) satisfies ChatListItem),
     ];
-  }, [pendingPermission, pendingQuestion, session.id, sessionMessages, streamingText]);
+  }, [blockedPlaceholder, pendingPermission, pendingQuestion, session.id, sessionMessages, streamingMessage]);
 
   const handlePickFile = async () => {
     try {
@@ -302,13 +488,14 @@ export default function ChatTab({ session, server }: ChatTabProps) {
       // The stream will naturally end or error out, so we rely on that to clear loading state
       // But we can force it here for immediate UI feedback
       setLoading(false);
+      setBlockedPlaceholder(null);
     } catch (error) {
       console.error('Error aborting session:', error);
       Alert.alert('Error', 'Failed to stop generation');
     }
   };
 
-  const handleSend = async () => {
+  const handleSend = useCallback(async () => {
     if (!input.trim() && attachments.length === 0) return;
 
     const messageText = input;
@@ -325,7 +512,10 @@ export default function ChatTab({ session, server }: ChatTabProps) {
     const currentAttachments = [...attachments];
     setAttachments([]);
     setLoading(true);
-    setStreamingText('');
+    setStreamingMessage(null);
+    setPendingQuestion(null);
+    setPendingPermission(null);
+    setBlockedPlaceholder(null);
 
     try {
       const preparedAttachments = await Promise.all(
@@ -351,30 +541,35 @@ export default function ChatTab({ session, server }: ChatTabProps) {
         })
       );
 
-      let streamedText = '';
-
       await service.streamMessage(
         session.id,
         messageText,
         preparedAttachments.length > 0 ? preparedAttachments : undefined,
         {
-          onTextDelta: (delta) => {
-            streamedText += delta;
-            setStreamingText(streamedText);
+          onPartUpdated: (part, delta) => {
+            if (!streamingMessage && isUserPromptEcho(part, delta, messageText)) {
+              return;
+            }
+            setStreamingMessage((current) => applyStreamUpdate(current, session.id, part, delta));
+            setBlockedPlaceholder(null);
           },
-          onQuestionAsked: (event) => {
-            setPendingQuestion(event);
+          onQuestionAsked: async (event) => {
+            setBlockedPlaceholder('question');
+            setPendingQuestion(null);
+            setPendingPermission(null);
+            await syncSessionState({ fallbackQuestion: event });
           },
-          onPermissionAsked: (event) => {
-            setPendingPermission(event);
+          onPermissionAsked: async (event) => {
+            setBlockedPlaceholder('permission');
+            setPendingPermission(null);
+            setPendingQuestion(null);
+            await syncSessionState({ fallbackPermission: event });
           },
           onComplete: async () => {
             // Fetch final messages from server to get rich parts
             // (tool calls, reasoning blocks, attachments, etc.)
             try {
-              const apiMessages = await service.getMessages(session.id);
-              const chatMessages = apiMessages.map(convertApiMessageToChatMessage);
-              setMessages(session.id, chatMessages);
+              await syncSessionState({ clearStreaming: true });
             } catch (err) {
               console.error('Error fetching final messages:', err);
             }
@@ -383,21 +578,17 @@ export default function ChatTab({ session, server }: ChatTabProps) {
         selectedAgent
       );
 
-      setStreamingText('');
     } catch (error) {
       console.error('Error sending message:', error);
       // On SSE failure, try to reload messages from server
       try {
-        const apiMessages = await service.getMessages(session.id);
-        const chatMessages = apiMessages.map(convertApiMessageToChatMessage);
-        setMessages(session.id, chatMessages);
+        await syncSessionState({ clearStreaming: true });
       } catch (_) {}
       Alert.alert('Error', 'Failed to send message');
     } finally {
       setLoading(false);
-      setStreamingText('');
     }
-  };
+  }, [addMessage, attachments, input, selectedAgent, service, session.id, syncSessionState]);
 
   /**
    * Reply to a pending question from the server.
@@ -406,13 +597,14 @@ export default function ChatTab({ session, server }: ChatTabProps) {
    * continue receiving events once the server unblocks.
    */
   const handleAnswerQuestion = async (requestId: string, answers: string[][]) => {
-    setPendingQuestion(null);
-
     try {
       const ok = await service.replyToQuestion(requestId, answers);
       if (!ok) {
         Alert.alert('Error', 'Failed to send answer to server');
+        return;
       }
+      setPendingQuestion(null);
+      setBlockedPlaceholder(null);
       // The original SSE stream is still open.
       // When the LLM resumes, we'll get more message.part.updated events,
       // and eventually session.status: idle → onComplete fires.
@@ -426,13 +618,15 @@ export default function ChatTab({ session, server }: ChatTabProps) {
    * Approve a pending permission request from the server.
    */
   const handleApprovePermission = async (requestId: string) => {
-    setPendingPermission(null);
-
     try {
       const ok = await service.approvePermission(requestId);
       if (!ok) {
         Alert.alert('Error', 'Failed to approve permission');
+        return;
       }
+      resolvedPermissionIdsRef.current.add(requestId);
+      setPendingPermission(null);
+      setBlockedPlaceholder(null);
     } catch (error) {
       console.error('Error approving permission:', error);
       Alert.alert('Error', 'Failed to approve permission');
@@ -443,13 +637,15 @@ export default function ChatTab({ session, server }: ChatTabProps) {
    * Deny a pending permission request from the server.
    */
   const handleDenyPermission = async (requestId: string) => {
-    setPendingPermission(null);
-
     try {
       const ok = await service.denyPermission(requestId);
       if (!ok) {
         Alert.alert('Error', 'Failed to deny permission');
+        return;
       }
+      resolvedPermissionIdsRef.current.add(requestId);
+      setPendingPermission(null);
+      setBlockedPlaceholder(null);
     } catch (error) {
       console.error('Error denying permission:', error);
       Alert.alert('Error', 'Failed to deny permission');
@@ -489,6 +685,9 @@ export default function ChatTab({ session, server }: ChatTabProps) {
               return null;
 
             case 'reasoning':
+              if (!part.content?.trim()) {
+                return null;
+              }
               return (
                 <View key={idx} className="border-l-2 border-info pl-2 mb-2 opacity-70">
                   <Text className="text-text-muted text-[10px] font-semibold mb-0.5">Thinking</Text>
@@ -577,31 +776,41 @@ export default function ChatTab({ session, server }: ChatTabProps) {
         return renderMessage(item.message);
       case 'streaming':
         return (
-          <View className="self-start w-full py-2 mb-3" testID="streaming-message">
+          <View testID="streaming-message">
+            {renderMessage(item.message)}
+            {!pendingQuestion && !pendingPermission && !blockedPlaceholder ? (
+              <StyledActivityIndicator className="mt-2 mb-3 self-start" />
+            ) : null}
+          </View>
+        );
+      case 'blocked-placeholder':
+        return (
+          <View className="self-start w-full py-2 mb-3" testID={`blocked-${item.promptType}`}>
             <Text className="text-text-muted font-semibold text-xs mb-1 px-1">Assistant</Text>
-            <MarkdownRenderer content={item.content} />
-            {!pendingQuestion && !pendingPermission && <StyledActivityIndicator className="mt-2" />}
+            <View className="bg-surface-elevated border border-border rounded-lg px-3 py-3 self-start">
+              <Text className="text-text font-medium">
+                {item.promptType === 'question' ? 'Asking question...' : 'Requesting permission...'}
+              </Text>
+            </View>
+            <StyledActivityIndicator className="mt-2 self-start" />
           </View>
         );
       case 'question':
         return (
           <View className="mb-3">
-            {item.event.questions.map((question, idx) => (
-              <QuestionDisplay
-                key={`${item.event.id}-${idx}`}
-                question={{
-                  requestId: item.event.id,
-                  question: question.question,
-                  header: question.header,
-                  options: question.options,
-                  multiple: question.multiple,
-                  custom: question.custom,
-                }}
-                onAnswer={(selectedLabels: string[]) => {
-                  handleAnswerQuestion(item.event.id, [selectedLabels]);
-                }}
-              />
-            ))}
+            <QuestionDisplay
+              questions={item.event.questions.map((question) => ({
+                requestId: item.event.id,
+                question: question.question,
+                header: question.header,
+                options: question.options,
+                multiple: question.multiple,
+                custom: question.custom,
+              }))}
+              onAnswer={(answers: string[][]) => {
+                handleAnswerQuestion(item.event.id, answers);
+              }}
+            />
           </View>
         );
       case 'permission':
@@ -610,9 +819,8 @@ export default function ChatTab({ session, server }: ChatTabProps) {
             <PermissionDisplay
               permission={{
                 requestId: item.event.id,
-                message: item.event.permission.message,
-                header: item.event.permission.header,
-                details: item.event.permission.details,
+                type: item.event.permission.type,
+                ...formatPermissionMessage(item.event),
               }}
               onApprove={() => handleApprovePermission(item.event.id)}
               onDeny={() => handleDenyPermission(item.event.id)}

--- a/src/components/chat/ChatTab.tsx
+++ b/src/components/chat/ChatTab.tsx
@@ -24,6 +24,7 @@ import {
   OpenCodeService,
   Message as ApiMessage,
   MessagePart as ApiMessagePart,
+  PermissionReply,
   StreamPartEvent,
   ToolMetadata,
   QuestionAskedEvent,
@@ -680,40 +681,21 @@ export default function ChatTab({ session, server }: ChatTabProps) {
   };
 
   /**
-   * Approve a pending permission request from the server.
+   * Reply to a pending permission request using the v2 reply semantics.
    */
-  const handleApprovePermission = async (requestId: string) => {
+  const handleReplyPermission = async (requestId: string, reply: PermissionReply) => {
     try {
-      const ok = await service.approvePermission(requestId);
+      const ok = await service.replyToPermission(requestId, reply);
       if (!ok) {
-        Alert.alert('Error', 'Failed to approve permission');
+        Alert.alert('Error', 'Failed to reply to permission');
         return;
       }
       resolvedPermissionIdsRef.current.add(requestId);
       setPendingPermission(null);
       setBlockedPlaceholder(null);
     } catch (error) {
-      console.error('Error approving permission:', error);
-      Alert.alert('Error', 'Failed to approve permission');
-    }
-  };
-
-  /**
-   * Deny a pending permission request from the server.
-   */
-  const handleDenyPermission = async (requestId: string) => {
-    try {
-      const ok = await service.denyPermission(requestId);
-      if (!ok) {
-        Alert.alert('Error', 'Failed to deny permission');
-        return;
-      }
-      resolvedPermissionIdsRef.current.add(requestId);
-      setPendingPermission(null);
-      setBlockedPlaceholder(null);
-    } catch (error) {
-      console.error('Error denying permission:', error);
-      Alert.alert('Error', 'Failed to deny permission');
+      console.error('Error replying to permission:', error);
+      Alert.alert('Error', 'Failed to reply to permission');
     }
   };
 
@@ -896,8 +878,7 @@ export default function ChatTab({ session, server }: ChatTabProps) {
                 type: item.event.permission.type,
                 ...formatPermissionMessage(item.event),
               }}
-              onApprove={() => handleApprovePermission(item.event.id)}
-              onDeny={() => handleDenyPermission(item.event.id)}
+              onReply={(reply) => handleReplyPermission(item.event.id, reply)}
             />
           </View>
         );

--- a/src/components/chat/PermissionDisplay.tsx
+++ b/src/components/chat/PermissionDisplay.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
 import { ChatPermission } from '../../types';
-import { useThemeColors } from '../../hooks/useThemeColors';
 
 interface PermissionDisplayProps {
   permission: ChatPermission;
@@ -18,7 +17,6 @@ export default function PermissionDisplay({
   onDeny, 
   answered = false 
 }: PermissionDisplayProps) {
-  const colors = useThemeColors();
   const [submitted, setSubmitted] = useState(false);
 
   const isDisabled = answered || submitted;
@@ -37,10 +35,9 @@ export default function PermissionDisplay({
 
   return (
     <View className="bg-surface-elevated p-4 rounded-lg border border-border mt-2">
-      {/* Header */}
-      {permission.header ? (
+      {permission.type ? (
         <Text className="text-text-muted text-xs font-semibold uppercase tracking-wide mb-1">
-          {permission.header}
+          {permission.type.replace(/_/g, ' ')}
         </Text>
       ) : null}
 
@@ -50,6 +47,12 @@ export default function PermissionDisplay({
       {/* Details (if provided) */}
       {permission.details ? (
         <Text className="text-text-subtle text-sm mb-3">{permission.details}</Text>
+      ) : null}
+
+      {permission.patterns && permission.patterns.length > 0 ? (
+        <Text className="text-text-subtle text-xs mb-3">
+          Allowed patterns: {permission.patterns.join(', ')}
+        </Text>
       ) : null}
 
       {/* Action buttons */}

--- a/src/components/chat/PermissionDisplay.tsx
+++ b/src/components/chat/PermissionDisplay.tsx
@@ -4,33 +4,23 @@ import { ChatPermission } from '../../types';
 
 interface PermissionDisplayProps {
   permission: ChatPermission;
-  /** Called when user approves the permission */
-  onApprove: () => void;
-  /** Called when user denies the permission */
-  onDeny: () => void;
+  onReply: (reply: 'once' | 'always' | 'reject') => void;
   answered?: boolean;
 }
 
 export default function PermissionDisplay({ 
   permission, 
-  onApprove, 
-  onDeny, 
+  onReply, 
   answered = false 
 }: PermissionDisplayProps) {
   const [submitted, setSubmitted] = useState(false);
 
   const isDisabled = answered || submitted;
 
-  const handleApprove = () => {
+  const handleReply = (reply: 'once' | 'always' | 'reject') => {
     if (isDisabled) return;
     setSubmitted(true);
-    onApprove();
-  };
-
-  const handleDeny = () => {
-    if (isDisabled) return;
-    setSubmitted(true);
-    onDeny();
+    onReply(reply);
   };
 
   return (
@@ -58,24 +48,38 @@ export default function PermissionDisplay({
       {/* Action buttons */}
       <View className="flex-row gap-2 mt-2">
         <TouchableOpacity
-          onPress={handleDeny}
-          disabled={isDisabled}
-          className={`flex-1 px-4 py-3 rounded-md border border-border bg-surface ${
-            isDisabled ? 'opacity-50' : ''
-          }`}
-        >
-          <Text className="text-text font-medium text-center">Deny</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          onPress={handleApprove}
+          onPress={() => handleReply('once')}
           disabled={isDisabled}
           className={`flex-1 px-4 py-3 rounded-md bg-primary ${
             isDisabled ? 'opacity-50' : ''
           }`}
         >
-          <Text className="text-on-primary font-medium text-center">Approve</Text>
+          <Text className="text-on-primary font-medium text-center">Once</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={() => handleReply('always')}
+          disabled={isDisabled}
+          className={`flex-1 px-4 py-3 rounded-md border border-border bg-surface ${
+            isDisabled ? 'opacity-50' : ''
+          }`}
+        >
+          <Text className="text-text font-medium text-center">Always</Text>
         </TouchableOpacity>
       </View>
+
+      <TouchableOpacity
+        onPress={() => handleReply('reject')}
+        disabled={isDisabled}
+        className={`px-4 py-3 rounded-md bg-danger mt-2 ${
+          isDisabled ? 'opacity-50' : ''
+        }`}
+      >
+        <Text className="text-on-primary font-medium text-center">Deny</Text>
+      </TouchableOpacity>
+
+      <Text className="text-text-subtle text-xs mt-3">
+        Once approves just this request. Always remembers this pattern for future requests.
+      </Text>
     </View>
   );
 }

--- a/src/components/chat/QuestionDisplay.tsx
+++ b/src/components/chat/QuestionDisplay.tsx
@@ -1,151 +1,146 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { View, Text, TouchableOpacity, TextInput } from 'react-native';
 import { ChatQuestion } from '../../types';
 import { useThemeColors } from '../../hooks/useThemeColors';
 
 interface QuestionDisplayProps {
-  question: ChatQuestion;
-  /** Called with an array of selected option labels (or custom text entries) */
-  onAnswer: (selectedLabels: string[]) => void;
+  questions: ChatQuestion[];
+  onAnswer: (answers: string[][]) => void;
   answered?: boolean;
 }
 
-export default function QuestionDisplay({ question, onAnswer, answered = false }: QuestionDisplayProps) {
+export default function QuestionDisplay({ questions, onAnswer, answered = false }: QuestionDisplayProps) {
   const colors = useThemeColors();
-  const [selectedOptions, setSelectedOptions] = useState<Set<string>>(new Set());
-  const [customText, setCustomText] = useState('');
+  const [selectedOptions, setSelectedOptions] = useState<string[][]>(() => questions.map(() => []));
+  const [customTexts, setCustomTexts] = useState<string[]>(() => questions.map(() => ''));
   const [submitted, setSubmitted] = useState(false);
 
   const isDisabled = answered || submitted;
 
-  const handleToggleOption = (label: string) => {
+  const answers = useMemo(
+    () => questions.map((question, index) => {
+      const values = [...selectedOptions[index]];
+      const customText = customTexts[index]?.trim();
+      if (question.custom && customText) {
+        values.push(customText);
+      }
+      return values;
+    }),
+    [customTexts, questions, selectedOptions],
+  );
+
+  const hasAnyAnswer = answers.some((value) => value.length > 0);
+
+  const toggleOption = (questionIndex: number, label: string) => {
     if (isDisabled) return;
 
-    if (question.multiple) {
-      // Multi-select: toggle the option in/out of the set
-      setSelectedOptions((prev) => {
-        const next = new Set(prev);
-        if (next.has(label)) {
-          next.delete(label);
+    setSelectedOptions((prev) => {
+      const next = [...prev];
+      const current = new Set(next[questionIndex] || []);
+
+      if (questions[questionIndex].multiple) {
+        if (current.has(label)) {
+          current.delete(label);
         } else {
-          next.add(label);
+          current.add(label);
         }
-        return next;
-      });
-    } else {
-      // Single-select: pick immediately and submit
-      setSubmitted(true);
-      onAnswer([label]);
-    }
+        next[questionIndex] = Array.from(current);
+      } else {
+        next[questionIndex] = [label];
+      }
+
+      return next;
+    });
   };
 
-  const handleSubmitMultiple = () => {
+  const updateCustomText = (questionIndex: number, value: string) => {
     if (isDisabled) return;
-    const labels = Array.from(selectedOptions);
-    if (labels.length === 0 && !customText.trim()) return;
 
-    const answers = [...labels];
-    if (customText.trim()) {
-      answers.push(customText.trim());
-    }
+    setCustomTexts((prev) => {
+      const next = [...prev];
+      next[questionIndex] = value;
+      return next;
+    });
+  };
+
+  const handleSubmit = () => {
+    if (isDisabled || !hasAnyAnswer) return;
     setSubmitted(true);
     onAnswer(answers);
   };
 
-  const handleSubmitCustomOnly = () => {
-    if (isDisabled || !customText.trim()) return;
-    setSubmitted(true);
-    onAnswer([customText.trim()]);
-  };
-
-  const hasOptions = question.options && question.options.length > 0;
-
   return (
     <View className="bg-surface-elevated p-4 rounded-lg border border-border mt-2">
-      {/* Header */}
-      {question.header ? (
-        <Text className="text-text-muted text-xs font-semibold uppercase tracking-wide mb-1">
-          {question.header}
-        </Text>
-      ) : null}
+      {questions.map((question, questionIndex) => {
+        const hasOptions = question.options && question.options.length > 0;
+        const selected = new Set(selectedOptions[questionIndex] || []);
+        const customText = customTexts[questionIndex] || '';
 
-      {/* Question text */}
-      <Text className="text-text font-medium mb-3">{question.question}</Text>
+        return (
+          <View key={`${question.requestId}-${questionIndex}`} className={questionIndex > 0 ? 'mt-4 pt-4 border-t border-border' : ''}>
+            {question.header ? (
+              <Text className="text-text-muted text-xs font-semibold uppercase tracking-wide mb-1">
+                {question.header}
+              </Text>
+            ) : null}
 
-      {/* Options list */}
-      {hasOptions && (
-        <View className="mb-2">
-          {question.options.map((opt) => {
-            const isSelected = selectedOptions.has(opt.label);
-            return (
-              <TouchableOpacity
-                key={opt.label}
-                onPress={() => handleToggleOption(opt.label)}
-                disabled={isDisabled}
-                className={`p-3 rounded-md border mb-2 ${
-                  isSelected
-                    ? 'bg-primary/10 border-primary'
-                    : 'bg-surface border-border'
-                } ${isDisabled && !isSelected ? 'opacity-50' : ''}`}
-              >
-                <Text
-                  className={`${
-                    isSelected ? 'text-primary' : 'text-text'
-                  } font-medium`}
-                >
-                  {opt.label}
-                </Text>
-                {opt.description ? (
-                  <Text className="text-text-subtle text-xs mt-0.5">
-                    {opt.description}
-                  </Text>
-                ) : null}
-              </TouchableOpacity>
-            );
-          })}
-        </View>
-      )}
+            {questions.length > 1 ? (
+              <Text className="text-text-subtle text-xs mb-1">Question {questionIndex + 1}</Text>
+            ) : null}
 
-      {/* Custom text input - always available for "Other" option */}
+            <Text className="text-text font-medium mb-3">{question.question}</Text>
+
+            {hasOptions && (
+              <View className="mb-2">
+                {question.options.map((opt) => {
+                  const isSelected = selected.has(opt.label);
+                  return (
+                    <TouchableOpacity
+                      key={opt.label}
+                      onPress={() => toggleOption(questionIndex, opt.label)}
+                      disabled={isDisabled}
+                      className={`p-3 rounded-md border mb-2 ${
+                        isSelected ? 'bg-primary/10 border-primary' : 'bg-surface border-border'
+                      } ${isDisabled && !isSelected ? 'opacity-50' : ''}`}
+                    >
+                      <Text className={`${isSelected ? 'text-primary' : 'text-text'} font-medium`}>
+                        {opt.label}
+                      </Text>
+                      {opt.description ? (
+                        <Text className="text-text-subtle text-xs mt-0.5">{opt.description}</Text>
+                      ) : null}
+                    </TouchableOpacity>
+                  );
+                })}
+              </View>
+            )}
+
+            {question.custom ? (
+              <View className={`p-3 rounded-md border ${customText.trim() ? 'bg-primary/10 border-primary' : 'bg-surface border-border'}`}>
+                <TextInput
+                  value={customText}
+                  onChangeText={(value) => updateCustomText(questionIndex, value)}
+                  editable={!isDisabled}
+                  placeholder="Type your answer..."
+                  placeholderTextColor={colors.textSubtle}
+                  className={`${customText.trim() ? 'text-primary' : 'text-text'} font-medium`}
+                  returnKeyType="done"
+                />
+              </View>
+            ) : null}
+          </View>
+        );
+      })}
+
       <TouchableOpacity
-        onPress={() => {
-          // In single-select mode with options, allow clicking to submit custom text
-          if (!question.multiple && hasOptions && customText.trim()) {
-            handleSubmitCustomOnly();
-          }
-        }}
-        disabled={isDisabled || !customText.trim() || question.multiple || !hasOptions}
-        activeOpacity={!question.multiple && hasOptions && customText.trim() ? 0.7 : 1}
-        className={`p-3 rounded-md border mb-2 ${
-          customText.trim()
-            ? 'bg-primary/10 border-primary'
-            : 'bg-surface border-border'
-        } ${isDisabled && !customText.trim() ? 'opacity-50' : ''}`}
+        onPress={handleSubmit}
+        disabled={isDisabled || !hasAnyAnswer}
+        className={`px-4 py-3 rounded-md bg-primary self-end mt-4 ${
+          isDisabled || !hasAnyAnswer ? 'opacity-50' : ''
+        }`}
       >
-        <TextInput
-          value={customText}
-          onChangeText={setCustomText}
-          editable={!isDisabled}
-          placeholder="Other (type your answer)..."
-          placeholderTextColor={colors.textSubtle}
-          className={`${customText.trim() ? 'text-primary' : 'text-text'} font-medium`}
-          onSubmitEditing={hasOptions && question.multiple ? handleSubmitMultiple : handleSubmitCustomOnly}
-          returnKeyType="send"
-        />
+        <Text className="text-on-primary font-medium">Confirm</Text>
       </TouchableOpacity>
-
-      {/* Submit button for multi-select mode */}
-      {question.multiple && hasOptions && (
-        <TouchableOpacity
-          onPress={handleSubmitMultiple}
-          disabled={isDisabled || (selectedOptions.size === 0 && !customText.trim())}
-          className={`px-4 py-2 rounded-md bg-primary self-end ${
-            isDisabled || (selectedOptions.size === 0 && !customText.trim()) ? 'opacity-50' : ''
-          }`}
-        >
-          <Text className="text-on-primary font-medium">Confirm</Text>
-        </TouchableOpacity>
-      )}
     </View>
   );
 }

--- a/src/context/NotificationProvider.tsx
+++ b/src/context/NotificationProvider.tsx
@@ -9,11 +9,12 @@
  * from background, reconnects the SSE and polls the server to catch up
  * on anything that happened while JS was suspended.
  */
-import React, { createContext, useContext, useEffect, useRef, useCallback } from 'react';
-import { AppState, AppStateStatus, Platform } from 'react-native';
+import React, { createContext, useContext, useEffect, useRef, useCallback, useState } from 'react';
+import { AppState, AppStateStatus } from 'react-native';
 import EventSource from 'react-native-sse';
+import base64 from 'base-64';
 import { useStore } from '../store';
-import { OpenCodeService, QuestionAskedEvent } from '../services/opencode';
+import { OpenCodeService, PermissionAskedEvent, QuestionAskedEvent } from '../services/opencode';
 import { notificationService } from '../services/notifications';
 import { savePollState, PollState } from '../services/notificationState';
 import { Server } from '../types';
@@ -28,10 +29,13 @@ const MAX_RECONNECT_MS = 30000;
 interface NotificationContextValue {
   /** Currently pending questions across all sessions (from SSE) */
   pendingQuestions: QuestionAskedEvent[];
+  /** Currently pending permissions across all sessions (from SSE) */
+  pendingPermissions: PermissionAskedEvent[];
 }
 
 const NotificationContext = createContext<NotificationContextValue>({
   pendingQuestions: [],
+  pendingPermissions: [],
 });
 
 export function useNotificationContext() {
@@ -40,6 +44,8 @@ export function useNotificationContext() {
 
 export function NotificationProvider({ children }: { children: React.ReactNode }) {
   const { servers, sessions, viewedSessionId } = useStore();
+  const [pendingQuestions, setPendingQuestions] = useState<QuestionAskedEvent[]>([]);
+  const [pendingPermissions, setPendingPermissions] = useState<PermissionAskedEvent[]>([]);
 
   // Track which server we're currently connected to
   const connectedServerRef = useRef<Server | null>(null);
@@ -51,7 +57,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
   const lastMessageTimeRef = useRef<Map<string, number>>(new Map());
   const knownBusySessionsRef = useRef<Set<string>>(new Set());
   const knownQuestionIdsRef = useRef<Set<string>>(new Set());
-  const pendingQuestionsRef = useRef<QuestionAskedEvent[]>([]);
+  const knownPermissionIdsRef = useRef<Set<string>>(new Set());
 
   // AppState tracking
   const appStateRef = useRef<AppStateStatus>(AppState.currentState);
@@ -61,15 +67,6 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
     (sessionId: string) => {
       const session = sessions.find((s) => s.id === sessionId);
       return session?.title || 'Session';
-    },
-    [sessions],
-  );
-
-  // Get the server ID for a session (for notification data)
-  const getServerIdForSession = useCallback(
-    (sessionId: string) => {
-      const session = sessions.find((s) => s.id === sessionId);
-      return session?.serverId || connectedServerRef.current?.id || '';
     },
     [sessions],
   );
@@ -95,12 +92,11 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         eventSourceRef.current = null;
       }
 
-      const service = new OpenCodeService(server);
       const baseUrl = `http${server.useSSL ? 's' : ''}://${server.host}:${server.port}`;
       const headers: Record<string, string> = {};
 
       if (server.apiKey) {
-        headers.Authorization = `Basic ${btoa(`opencode:${server.apiKey}`)}`;
+        headers.Authorization = `Basic ${base64.encode(`opencode:${server.apiKey}`)}`;
       }
 
       const es = new EventSource(`${baseUrl}/event`, { headers });
@@ -215,11 +211,44 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
             questions: props.questions || [],
             tool: props.tool,
           };
-          pendingQuestionsRef.current = [...pendingQuestionsRef.current, event];
+          setPendingQuestions((prev) => [...prev.filter((item) => item.id !== event.id), event]);
 
           if (shouldNotify(sessionId)) {
             const title = getSessionTitle(sessionId);
             notificationService.notifyQuestionAsked(sessionId, server.id, title, header);
+          }
+        }
+        return;
+      }
+
+      // ── permission.asked ──
+      if (data.type === 'permission.asked' && props?.id) {
+        const permissionId = props.id;
+        if (!knownPermissionIdsRef.current.has(permissionId)) {
+          knownPermissionIdsRef.current.add(permissionId);
+
+          const sessionId = props.sessionID;
+          const event: PermissionAskedEvent = {
+            id: props.id,
+            sessionID: sessionId,
+            permission: {
+              type: props.permission,
+              patterns: props.patterns,
+              metadata: props.metadata,
+              always: props.always,
+            },
+            tool: props.tool,
+          };
+          setPendingPermissions((prev) => [...prev.filter((item) => item.id !== event.id), event]);
+
+          if (shouldNotify(sessionId)) {
+            const title = getSessionTitle(sessionId);
+            notificationService.notifyPermissionAsked(
+              sessionId,
+              server.id,
+              title,
+              props.permission,
+            );
           }
         }
         return;
@@ -235,9 +264,10 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
       try {
         const service = new OpenCodeService(server);
 
-        const [statuses, questions] = await Promise.all([
+        const [statuses, questions, permissions] = await Promise.all([
           service.getSessionStatuses(),
           service.listPendingQuestions(),
+          service.listPendingPermissions(),
         ]);
 
         const currentBusyIds = new Set(Object.keys(statuses));
@@ -258,16 +288,35 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
             const sessionId = q.sessionID;
             const header = q.questions?.[0]?.header || '';
 
-            pendingQuestionsRef.current = [...pendingQuestionsRef.current, {
+            setPendingQuestions((prev) => [...prev.filter((item) => item.id !== q.id), {
               id: q.id,
               sessionID: sessionId,
               questions: q.questions || [],
               tool: q.tool,
-            }];
+            }]);
 
             if (shouldNotify(sessionId)) {
               const title = getSessionTitle(sessionId);
               notificationService.notifyQuestionAsked(sessionId, server.id, title, header);
+            }
+          }
+        }
+
+        for (const permission of permissions) {
+          if (!knownPermissionIdsRef.current.has(permission.id)) {
+            knownPermissionIdsRef.current.add(permission.id);
+
+            const sessionId = permission.sessionID;
+            setPendingPermissions((prev) => [...prev.filter((item) => item.id !== permission.id), permission]);
+
+            if (shouldNotify(sessionId)) {
+              const title = getSessionTitle(sessionId);
+              notificationService.notifyPermissionAsked(
+                sessionId,
+                server.id,
+                title,
+                permission.permission.type,
+              );
             }
           }
         }
@@ -287,9 +336,15 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         const pollState: PollState = {
           busySessionIds: Array.from(currentBusyIds),
           pendingQuestionIds: questions.map((q) => q.id),
+          pendingPermissionIds: permissions.map((permission) => permission.id),
           timestamp: Date.now(),
         };
         await savePollState(server.id, pollState);
+
+        knownQuestionIdsRef.current = new Set(questions.map((q) => q.id));
+        knownPermissionIdsRef.current = new Set(permissions.map((permission) => permission.id));
+        setPendingQuestions(questions);
+        setPendingPermissions(permissions);
       } catch (err) {
         console.error('Error polling server on resume:', err);
       }
@@ -362,7 +417,8 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
   }, [connectSSE, pollServerOnResume]);
 
   const contextValue: NotificationContextValue = {
-    pendingQuestions: pendingQuestionsRef.current,
+    pendingQuestions,
+    pendingPermissions,
   };
 
   return (

--- a/src/services/notificationState.ts
+++ b/src/services/notificationState.ts
@@ -11,6 +11,8 @@ export interface PollState {
   busySessionIds: string[];
   /** Pending question request IDs at the time of this poll */
   pendingQuestionIds: string[];
+  /** Pending permission request IDs at the time of this poll */
+  pendingPermissionIds: string[];
   /** Unix timestamp (ms) of when this poll ran */
   timestamp: number;
 }

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -4,7 +4,7 @@ import { Platform } from 'react-native';
 
 const CHANNEL_ID = 'opencode-default';
 
-export type NotificationType = 'agent-active' | 'agent-finished' | 'question-asked';
+export type NotificationType = 'agent-active' | 'agent-finished' | 'question-asked' | 'permission-asked';
 
 export interface NotificationData {
   sessionId: string;
@@ -110,6 +110,20 @@ class NotificationService {
       'Agent needs your input',
       header ? `${header} - "${sessionTitle}"` : `Question in "${sessionTitle}"`,
       { sessionId, serverId, type: 'question-asked' },
+    );
+  }
+
+  /** Fire a "permission asked" notification */
+  async notifyPermissionAsked(
+    sessionId: string,
+    serverId: string,
+    sessionTitle: string,
+    header?: string,
+  ): Promise<string> {
+    return this.notify(
+      'Agent needs approval',
+      header ? `${header} - "${sessionTitle}"` : `Permission requested in "${sessionTitle}"`,
+      { sessionId, serverId, type: 'permission-asked' },
     );
   }
 

--- a/src/services/opencode.ts
+++ b/src/services/opencode.ts
@@ -93,6 +93,8 @@ export interface StreamPartUpdated {
 
 export type StreamPartEvent = StreamPartUpdated | StreamPartDelta;
 
+export type PermissionReply = 'once' | 'always' | 'reject';
+
 /** Shape of an individual question inside a question.asked SSE event */
 export interface QuestionOption {
   label: string;
@@ -709,33 +711,18 @@ export class OpenCodeService {
   }
 
   /**
-   * Approve a permission request.
+   * Reply to a permission request using the v2 API contract.
    */
-  async approvePermission(requestId: string): Promise<boolean> {
+  async replyToPermission(requestId: string, reply: PermissionReply, message?: string): Promise<boolean> {
     try {
-      const response = await fetch(`${this.baseUrl}/permission/${requestId}/approve`, {
+      const response = await fetch(`${this.baseUrl}/permission/${requestId}/reply`, {
         method: 'POST',
         headers: this.getHeaders(),
+        body: JSON.stringify({ reply, ...(message ? { message } : {}) }),
       });
       return response.ok;
     } catch (error) {
-      console.error('Error approving permission:', error);
-      return false;
-    }
-  }
-
-  /**
-   * Deny a permission request.
-   */
-  async denyPermission(requestId: string): Promise<boolean> {
-    try {
-      const response = await fetch(`${this.baseUrl}/permission/${requestId}/deny`, {
-        method: 'POST',
-        headers: this.getHeaders(),
-      });
-      return response.ok;
-    } catch (error) {
-      console.error('Error denying permission:', error);
+      console.error('Error replying to permission:', error);
       return false;
     }
   }

--- a/src/services/opencode.ts
+++ b/src/services/opencode.ts
@@ -127,7 +127,7 @@ export interface PermissionItem {
 
 /** Payload from the server's `permission.asked` SSE event */
 export interface PermissionAskedEvent {
-  id: string;           // requestID – used for approve/deny
+  id: string;           // requestID – used for v2 permission replies
   sessionID: string;
   permission: PermissionItem;
   tool?: { messageID: string; callID: string };

--- a/src/services/opencode.ts
+++ b/src/services/opencode.ts
@@ -2,12 +2,18 @@ import { Server, Session, GitFile, Project, FileNode, Agent } from '../types';
 import EventSource from 'react-native-sse';
 import base64 from 'base-64';
 
-export interface TextPart {
+interface PartEnvelope {
+  id?: string;
+  messageID?: string;
+  sessionID?: string;
+}
+
+export interface TextPart extends PartEnvelope {
   type: 'text';
   text: string;
 }
 
-export interface ReasoningPart {
+export interface ReasoningPart extends PartEnvelope {
   type: 'reasoning';
   text: string;
 }
@@ -31,7 +37,7 @@ export interface ToolInvocationResult {
 
 export type ToolInvocation = ToolInvocationCall | ToolInvocationResult;
 
-export interface ToolInvocationPart {
+export interface ToolInvocationPart extends PartEnvelope {
   type: 'tool-invocation';
   toolInvocation: ToolInvocation;
 }
@@ -69,6 +75,23 @@ export type MessagePart =
   | StepStartPart
   | FilePart
   | ImagePart;
+
+export interface StreamPartDelta {
+  type: 'message.part.delta';
+  sessionID: string;
+  messageID: string;
+  partID: string;
+  field: string;
+  delta: string;
+}
+
+export interface StreamPartUpdated {
+  type: 'message.part.updated';
+  part: MessagePart;
+  delta?: string;
+}
+
+export type StreamPartEvent = StreamPartUpdated | StreamPartDelta;
 
 /** Shape of an individual question inside a question.asked SSE event */
 export interface QuestionOption {
@@ -453,7 +476,7 @@ export class OpenCodeService {
     attachments?: Array<{ type: string; content: string; name: string; mimeType?: string }>,
     callbacks?: {
       onTextDelta?: (delta: string) => void;
-      onPartUpdated?: (part: any, delta?: string) => void;
+      onPartUpdated?: (event: StreamPartEvent) => void;
       onQuestionAsked?: (event: QuestionAskedEvent) => void;
       onPermissionAsked?: (event: PermissionAskedEvent) => void;
       onComplete?: () => void;
@@ -519,7 +542,7 @@ export class OpenCodeService {
             return;
           }
 
-          // Incremental text delta from assistant
+          // Full part snapshot updates from assistant
           if (data.type === 'message.part.updated') {
             const part = data.properties?.part;
             const delta = data.properties?.delta;
@@ -528,7 +551,31 @@ export class OpenCodeService {
               if (delta && part.type === 'text') {
                 callbacks?.onTextDelta?.(delta);
               }
-              callbacks?.onPartUpdated?.(part, delta);
+              callbacks?.onPartUpdated?.({
+                type: 'message.part.updated',
+                part,
+                ...(delta ? { delta } : {}),
+              });
+            }
+            return;
+          }
+
+          // Forward-compatible delta events from newer API transports
+          if (data.type === 'message.part.delta') {
+            const props = data.properties;
+
+            if (props?.sessionID === sessionId) {
+              if (props?.field === 'text' && props?.delta) {
+                callbacks?.onTextDelta?.(props.delta);
+              }
+              callbacks?.onPartUpdated?.({
+                type: 'message.part.delta',
+                sessionID: props.sessionID,
+                messageID: props.messageID,
+                partID: props.partID,
+                field: props.field,
+                delta: props.delta,
+              });
             }
             return;
           }

--- a/src/services/opencode.ts
+++ b/src/services/opencode.ts
@@ -94,9 +94,10 @@ export interface QuestionAskedEvent {
 
 /** Permission request item */
 export interface PermissionItem {
-  message: string;
-  header?: string;
-  details?: string;
+  type: string;
+  patterns?: string[];
+  metadata?: Record<string, any>;
+  always?: string[];
 }
 
 /** Payload from the server's `permission.asked` SSE event */
@@ -105,6 +106,36 @@ export interface PermissionAskedEvent {
   sessionID: string;
   permission: PermissionItem;
   tool?: { messageID: string; callID: string };
+}
+
+function normalizePermissionEvent(raw: any): PermissionAskedEvent {
+  const permission = raw?.permission;
+
+  if (typeof permission === 'string') {
+    return {
+      id: raw.id,
+      sessionID: raw.sessionID,
+      permission: {
+        type: permission,
+        patterns: raw.patterns,
+        metadata: raw.metadata,
+        always: raw.always,
+      },
+      tool: raw.tool,
+    };
+  }
+
+  return {
+    id: raw.id,
+    sessionID: raw.sessionID,
+    permission: {
+      type: permission?.type || 'unknown',
+      patterns: permission?.patterns ?? raw.patterns,
+      metadata: permission?.metadata ?? raw.metadata,
+      always: permission?.always ?? raw.always,
+    },
+    tool: raw.tool,
+  };
 }
 
 export interface ToolMetadata {
@@ -422,7 +453,7 @@ export class OpenCodeService {
     attachments?: Array<{ type: string; content: string; name: string; mimeType?: string }>,
     callbacks?: {
       onTextDelta?: (delta: string) => void;
-      onPartUpdated?: (part: any) => void;
+      onPartUpdated?: (part: any, delta?: string) => void;
       onQuestionAsked?: (event: QuestionAskedEvent) => void;
       onPermissionAsked?: (event: PermissionAskedEvent) => void;
       onComplete?: () => void;
@@ -494,10 +525,10 @@ export class OpenCodeService {
             const delta = data.properties?.delta;
 
             if (part?.sessionID === sessionId) {
-              if (delta && (part.type === 'text' || part.type === 'reasoning')) {
+              if (delta && part.type === 'text') {
                 callbacks?.onTextDelta?.(delta);
               }
-              callbacks?.onPartUpdated?.(part);
+              callbacks?.onPartUpdated?.(part, delta);
             }
             return;
           }
@@ -521,10 +552,7 @@ export class OpenCodeService {
             const props = data.properties;
             if (props?.sessionID === sessionId) {
               callbacks?.onPermissionAsked?.({
-                id: props.id,
-                sessionID: props.sessionID,
-                permission: props.permission,
-                tool: props.tool,
+                ...normalizePermissionEvent(props),
               });
             }
             return;
@@ -674,7 +702,8 @@ export class OpenCodeService {
         headers: this.getHeaders(),
       });
       if (!response.ok) throw new Error('Failed to fetch pending permissions');
-      return response.json();
+      const data = await response.json();
+      return data.map((item: any) => normalizePermissionEvent(item));
     } catch (error) {
       console.error('Error fetching pending permissions:', error);
       return [];

--- a/src/tasks/backgroundPoll.ts
+++ b/src/tasks/backgroundPoll.ts
@@ -6,7 +6,7 @@
  *
  * When the app is backgrounded, the OS periodically wakes us up
  * (minimum ~15 min on both platforms) to poll each configured server
- * for status changes and pending questions.
+ * for status changes and pending questions/permissions.
  */
 import * as TaskManager from 'expo-task-manager';
 import * as BackgroundTask from 'expo-background-task';
@@ -43,18 +43,23 @@ TaskManager.defineTask(BACKGROUND_POLL_TASK, async () => {
         const sessionTitleMap = new Map(sessions.map((s) => [s.id, s.title]));
 
         // Fetch current state from server
-        const [statuses, questions] = await Promise.all([
+        const [statuses, questions, permissions] = await Promise.all([
           service.getSessionStatuses(),
           service.listPendingQuestions(),
+          service.listPendingPermissions(),
         ]);
 
         const currentBusyIds = Object.keys(statuses);
         const currentQuestionIds = questions.map((q) => q.id);
+        const currentPermissionIds = permissions.map((p) => p.id);
 
         // Load previous poll state for diffing
         const prevState = await loadPollState(server.id);
 
         if (prevState) {
+          const previousQuestionIds = prevState.pendingQuestionIds || [];
+          const previousPermissionIds = prevState.pendingPermissionIds || [];
+
           // Detect sessions that were busy but are now idle → agent finished
           for (const prevBusyId of prevState.busySessionIds) {
             if (!currentBusyIds.includes(prevBusyId)) {
@@ -65,10 +70,22 @@ TaskManager.defineTask(BACKGROUND_POLL_TASK, async () => {
 
           // Detect new pending questions
           for (const q of questions) {
-            if (!prevState.pendingQuestionIds.includes(q.id)) {
+            if (!previousQuestionIds.includes(q.id)) {
               const title = sessionTitleMap.get(q.sessionID) || 'Session';
               const header = q.questions?.[0]?.header || '';
               await notificationService.notifyQuestionAsked(q.sessionID, server.id, title, header);
+            }
+          }
+
+          for (const permission of permissions) {
+            if (!previousPermissionIds.includes(permission.id)) {
+              const title = sessionTitleMap.get(permission.sessionID) || 'Session';
+              await notificationService.notifyPermissionAsked(
+                permission.sessionID,
+                server.id,
+                title,
+                permission.permission.type,
+              );
             }
           }
 
@@ -85,6 +102,7 @@ TaskManager.defineTask(BACKGROUND_POLL_TASK, async () => {
         const newState: PollState = {
           busySessionIds: currentBusyIds,
           pendingQuestionIds: currentQuestionIds,
+          pendingPermissionIds: currentPermissionIds,
           timestamp: Date.now(),
         };
         await savePollState(server.id, newState);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -116,6 +116,7 @@ export interface ChatPermission {
 }
 
 export interface ChatMessagePart {
+  id?: string;
   type: 'text' | 'tool-call' | 'reasoning';
   content?: string;
   toolCall?: ChatMessageToolCall;
@@ -170,4 +171,3 @@ export interface TerminalState {
   currentInput: string;
   isProcessing: boolean;
 }
-

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -103,7 +103,7 @@ export interface ChatQuestion {
 }
 
 export interface ChatPermission {
-  /** The requestID from the server (e.g. "perm_...") — used for approve/deny */
+  /** The requestID from the server (e.g. "per_...") — used for v2 permission replies */
   requestId: string;
   /** Permission kind from the server */
   type: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -105,12 +105,14 @@ export interface ChatQuestion {
 export interface ChatPermission {
   /** The requestID from the server (e.g. "perm_...") — used for approve/deny */
   requestId: string;
-  /** The permission request description */
+  /** Permission kind from the server */
+  type: string;
+  /** Human-readable summary for display */
   message: string;
-  /** Short header label */
-  header?: string;
-  /** Optional detailed explanation */
+  /** Optional secondary detail */
   details?: string;
+  /** Optional path patterns involved in the request */
+  patterns?: string[];
 }
 
 export interface ChatMessagePart {
@@ -168,5 +170,4 @@ export interface TerminalState {
   currentInput: string;
   isProcessing: boolean;
 }
-
 


### PR DESCRIPTION
## Summary
- switch the chat tab to an inverted message list and make transient stream updates durable, including better reasoning rendering and prompt/question/permission handling
- align the client with current OpenCode payloads and v2 permission replies, including `Once`, `Always`, and `Deny` actions in the permission UI
- add live OpenCode chat integration coverage for streaming, reasoning, questions, and the v2 permission lifecycle using temp test sessions